### PR TITLE
fix: fixed the transaction details tab issues

### DIFF
--- a/backend/src/modules/gold-lakehouse/gold-lakehouse.controller.ts
+++ b/backend/src/modules/gold-lakehouse/gold-lakehouse.controller.ts
@@ -17,6 +17,7 @@ import {
   TestAccountIdsResponse,
   TransactionPerspectivesResponse,
 } from './types/gold-lakehouse-responses.types';
+import { TransactionDetailDataResponse } from './types/transaction-detail.types';
 import { AccountConditionsSummary, ConditionsListByAccountResponse } from './types/IAccountConditions.types';
 import { AlertHistoryTimelineResponse } from './types/IAlertHistoryTimeline.types';
 import { AlertHistoryAlertsResponse } from './types/IAlertHistory.types';
@@ -87,81 +88,7 @@ export class GoldLakehouseController {
   async getTransactionDetailData(
     @Param('endToEndId') endToEndId: string,
     @Query('tenantId') tenantId?: string,
-  ): Promise<{
-    transactionOverview: {
-      transactionId: string;
-      transactionType: string;
-      timestamp: string;
-    };
-    transactionFlow: {
-      debtor: {
-        name: string;
-        account: {
-          iban: string;
-          type: string;
-        };
-        bank: string;
-      };
-      amount: {
-        amount: number;
-        currency: string;
-      };
-      creditor: {
-        name: string;
-        account: {
-          iban: string;
-          type: string;
-        };
-        bankName: string;
-      };
-    };
-    debtorProfile: {
-      name: string;
-      account: {
-        iban: string;
-        type: string;
-      };
-      bank: string;
-      swiftCode: string;
-      address: string;
-      accountType: string;
-    };
-    creditorProfile: {
-      name: string;
-      account: {
-        iban: string;
-        type: string;
-      };
-      bank: string;
-      swiftCode: string;
-      address: string;
-      accountType: string;
-    };
-    amountAndCurrency: Array<
-      | {
-          originalAmount: number;
-          exchangeRate: number;
-          convertedAmount: number;
-        }
-      | {
-          senderCharges: never[];
-          intermediaryCharges: never[];
-          receiverCharges: never[];
-        }
-      | {
-          totalCharges: number;
-        }
-    >;
-    settlementDetails: {
-      settlementDate: string;
-      reference: string;
-      purpose: string;
-    };
-    links: Array<{
-      rel: string;
-      href: string;
-    }>;
-  }> {
+  ): Promise<TransactionDetailDataResponse> {
     return await this.transactionLakehouseService.getTransactionDetailData(endToEndId, tenantId ?? 'DEFAULT');
   }
 

--- a/backend/src/modules/gold-lakehouse/transaction-lakehouse.service.ts
+++ b/backend/src/modules/gold-lakehouse/transaction-lakehouse.service.ts
@@ -148,6 +148,11 @@ export class TransactionLakehouseService extends GoldLakehouseService {
         ],
       };
     } catch (error: unknown) {
+      // Re-throw HttpExceptions as-is to preserve specific error messages
+      if (error instanceof HttpException) {
+        throw error;
+      }
+
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       const errorStack = error instanceof Error ? error.stack : undefined;
       this.logger.error(`Error fetching Transaction Detail data: ${errorMessage}`, errorStack);

--- a/backend/src/modules/gold-lakehouse/transaction-lakehouse.service.ts
+++ b/backend/src/modules/gold-lakehouse/transaction-lakehouse.service.ts
@@ -42,6 +42,7 @@ export class TransactionLakehouseService extends GoldLakehouseService {
         },
         columns: [
           'transaction_id',
+          'tx_msg_id',
           'tx_event_ts',
           'tx_type',
           'interbank_settlement_amount',
@@ -65,77 +66,78 @@ export class TransactionLakehouseService extends GoldLakehouseService {
         throw new HttpException('Transaction not found', HttpStatus.NOT_FOUND);
       }
 
-      const row = this.stripHudiMetadata(response.data[0]);
+      // Destructure pacs8 and pacs2 from response data
+      const pacs8 = response.data.find((record) => record.tx_type === 'pacs.008.001.10');
+      const pacs2 = response.data.find((record) => record.tx_type === 'pacs.002.001.12');
+
+      if (!pacs8) {
+        throw new HttpException('pacs.008 transaction not found', HttpStatus.NOT_FOUND);
+      }
+      if (!pacs2) {
+        throw new HttpException('pacs.002 transaction not found', HttpStatus.NOT_FOUND);
+      }
 
       // Transform to frontend-expected format
       return {
         transactionOverview: {
-          transactionId: String(row.transaction_id),
-          transactionType: String(row.tx_type),
-          timestamp: String(row.tx_event_ts),
+          pacs8: {
+            transactionId: String(pacs8.tx_msg_id),
+            transactionType: String(pacs8.tx_type),
+            timestamp: String(pacs8.tx_event_ts),
+          },
+          pacs2: {
+            transactionId: String(pacs2.tx_msg_id),
+            transactionType: String(pacs2.tx_type),
+            timestamp: String(pacs2.tx_event_ts),
+          },
         },
         transactionFlow: {
           debtor: {
-            name: String(row.debtor_name),
+            name: String(pacs8.debtor_name),
             account: {
-              iban: String(row.debtor_account_id),
-              type: 'CHECKING',
+              iban: String(pacs8.debtor_account_id),
             },
-            bank: String(row.instd_mmb_id),
+            bank: String(pacs8.instd_mmb_id),
           },
           amount: {
-            amount: Number(row.interbank_settlement_amount),
-            currency: String(row.interbank_settlement_currency) || 'USD',
+            amount: Number(pacs8.interbank_settlement_amount),
+            currency: String(pacs8.interbank_settlement_currency) || 'USD',
           },
           creditor: {
-            name: String(row.creditor_name),
+            name: String(pacs8.creditor_name),
             account: {
-              iban: String(row.creditor_account_id),
-              type: 'CHECKING',
+              iban: String(pacs8.creditor_account_id),
             },
-            bankName: String(row.instg_mmb_id),
+            bankName: String(pacs8.instg_mmb_id),
           },
         },
         debtorProfile: {
-          name: String(row.debtor_name),
+          name: String(pacs8.debtor_name),
           account: {
-            iban: String(row.debtor_account_id),
-            type: 'CHECKING',
+            iban: String(pacs8.debtor_account_id),
           },
-          bank: String(row.instd_mmb_id),
-          swiftCode: '',
-          address: '',
-          accountType: 'CHECKING',
+          bank: String(pacs8.instd_mmb_id),
         },
         creditorProfile: {
-          name: String(row.creditor_name),
+          name: String(pacs8.creditor_name),
           account: {
-            iban: String(row.creditor_account_id),
-            type: 'CHECKING',
+            iban: String(pacs8.creditor_account_id),
           },
-          bank: String(row.instg_mmb_id),
-          swiftCode: '',
-          address: '',
-          accountType: 'CHECKING',
+          bank: String(pacs8.instg_mmb_id),
         },
         amountAndCurrency: [
           {
-            originalAmount: Number(row.instructed_amount) || 0,
-            exchangeRate: Number(row.exchange_rate) || 1,
-            convertedAmount: Number(row.interbank_settlement_amount) || 0,
+            originalAmount: Number(pacs8.instructed_amount) || 0,
+            exchangeRate: Number(pacs8.exchange_rate) || 1,
+            convertedAmount: Number(pacs8.interbank_settlement_amount) || 0,
           },
           {
-            senderCharges: [],
-            intermediaryCharges: [],
-            receiverCharges: [],
-          },
-          {
-            totalCharges: Number(row.charge_total_amount),
+            totalCharges: Number(pacs8.charge_total_amount),
           },
         ],
         settlementDetails: {
-          settlementDate: String(row.tx_event_date),
-          reference: String(row.transaction_id),
+          settlementDate: String(pacs8.tx_event_date),
+          reference: String(pacs8.transaction_id),
           purpose: '',
         },
         links: [

--- a/backend/src/modules/gold-lakehouse/types/transaction-detail.types.ts
+++ b/backend/src/modules/gold-lakehouse/types/transaction-detail.types.ts
@@ -1,15 +1,21 @@
 export interface TransactionDetailDataResponse {
   transactionOverview: {
-    transactionId: string;
-    transactionType: string;
-    timestamp: string;
+    pacs8: {
+      transactionId: string;
+      transactionType: string;
+      timestamp: string;
+    };
+    pacs2: {
+      transactionId: string;
+      transactionType: string;
+      timestamp: string;
+    };
   };
   transactionFlow: {
     debtor: {
       name: string;
       account: {
         iban: string;
-        type: string;
       };
       bank: string;
     };
@@ -21,7 +27,6 @@ export interface TransactionDetailDataResponse {
       name: string;
       account: {
         iban: string;
-        type: string;
       };
       bankName: string;
     };
@@ -30,34 +35,21 @@ export interface TransactionDetailDataResponse {
     name: string;
     account: {
       iban: string;
-      type: string;
     };
     bank: string;
-    swiftCode: string;
-    address: string;
-    accountType: string;
   };
   creditorProfile: {
     name: string;
     account: {
       iban: string;
-      type: string;
     };
     bank: string;
-    swiftCode: string;
-    address: string;
-    accountType: string;
   };
   amountAndCurrency: Array<
     | {
         originalAmount: number;
         exchangeRate: number;
         convertedAmount: number;
-      }
-    | {
-        senderCharges: never[];
-        intermediaryCharges: never[];
-        receiverCharges: never[];
       }
     | {
         totalCharges: number;

--- a/backend/test/transaction-lakehouse.service.spec.ts
+++ b/backend/test/transaction-lakehouse.service.spec.ts
@@ -54,9 +54,10 @@ describe('TransactionLakehouseService', () => {
       http.mockReturnValue(
         okHttp([
           {
-            transaction_id: '123',
-            tx_type: 'PAYMENT',
-            tx_event_ts: '2024-01-01',
+            transaction_id: 500008,
+            tx_msg_id: '33c406b80b044dd1991900b120ff7730',
+            tx_type: 'pacs.008.001.10',
+            tx_event_ts: '2024-01-01T10:00:00',
             debtor_name: 'A',
             debtor_account_id: 'acc1',
             creditor_name: 'B',
@@ -69,17 +70,78 @@ describe('TransactionLakehouseService', () => {
             instructed_currency: 'USD',
             exchange_rate: 1,
             charge_total_amount: 0,
+            charge_currency: 'USD',
+            tx_event_date: '2024-01-01',
+          },
+          {
+            transaction_id: 39,
+            tx_msg_id: '09a77250f74a477d9fc4cba204fef5a9',
+            tx_type: 'pacs.002.001.12',
+            tx_event_ts: '2024-01-01T10:00:05',
+            debtor_name: null,
+            debtor_account_id: null,
+            creditor_name: null,
+            creditor_account_id: null,
+            instg_mmb_id: 'bank1',
+            instd_mmb_id: 'bank2',
+            interbank_settlement_amount: null,
+            interbank_settlement_currency: null,
+            instructed_amount: null,
+            instructed_currency: null,
+            exchange_rate: null,
+            charge_total_amount: 0,
+            charge_currency: 'USD',
             tx_event_date: '2024-01-01',
           },
         ]),
       );
       const result = await service.getTransactionDetailData('123');
       expect(result).toHaveProperty('transactionOverview');
+      expect(result.transactionOverview).toHaveProperty('pacs8');
+      expect(result.transactionOverview).toHaveProperty('pacs2');
+      expect(result.transactionOverview.pacs8.transactionId).toBe('33c406b80b044dd1991900b120ff7730');
+      expect(result.transactionOverview.pacs2.transactionId).toBe('09a77250f74a477d9fc4cba204fef5a9');
     });
 
     it('throws when transaction not found', async () => {
       http.mockReturnValue(okHttp([]));
       await expect(service.getTransactionDetailData('999')).rejects.toThrow(HttpException);
+    });
+
+    it('throws when pacs.008 not found', async () => {
+      http.mockReturnValue(
+        okHttp([
+          {
+            transaction_id: 39,
+            tx_msg_id: '09a77250f74a477d9fc4cba204fef5a9',
+            tx_type: 'pacs.002.001.12',
+            tx_event_ts: '2024-01-01T10:00:05',
+          },
+        ]),
+      );
+      await expect(service.getTransactionDetailData('999')).rejects.toThrow('pacs.008 transaction not found');
+    });
+
+    it('throws when pacs.002 not found', async () => {
+      http.mockReturnValue(
+        okHttp([
+          {
+            transaction_id: 500008,
+            tx_msg_id: '33c406b80b044dd1991900b120ff7730',
+            tx_type: 'pacs.008.001.10',
+            tx_event_ts: '2024-01-01T10:00:00',
+            debtor_name: 'A',
+            debtor_account_id: 'acc1',
+            creditor_name: 'B',
+            creditor_account_id: 'acc2',
+            instg_mmb_id: 'bank1',
+            instd_mmb_id: 'bank2',
+            interbank_settlement_amount: 100,
+            interbank_settlement_currency: 'USD',
+          },
+        ]),
+      );
+      await expect(service.getTransactionDetailData('999')).rejects.toThrow('pacs.002 transaction not found');
     });
 
     it('throws on error', async () => {

--- a/frontend/src/features/cases/components/view/visualizations/transactiondetails/TransactionDetailsTab.tsx
+++ b/frontend/src/features/cases/components/view/visualizations/transactiondetails/TransactionDetailsTab.tsx
@@ -112,38 +112,90 @@ const TransactionDetailsTab: React.FC<TransactionDetailsTabProps> = ({
         <h4 className="text-sm font-semibold text-gray-900 mb-4">
           Transaction Overview
         </h4>
-        <div className="grid grid-cols-4 gap-6">
-          <div>
-            <div className="text-xs font-medium text-gray-500 uppercase mb-1">
-              Transaction ID
+        
+        {/* PACS.008 - Payment Instruction */}
+        <div className="mb-6">
+          <div className="text-xs font-semibold text-gray-900 uppercase mb-3 flex items-center gap-2">
+            <span className="underline">PACS.008 - Payment Instruction</span>
+            <span className="px-2 py-0.5 bg-blue-100 text-blue-700 rounded text-xs">Primary</span>
+          </div>
+          <div className="grid grid-cols-4 gap-30">
+            <div>
+              <div className="text-xs font-medium text-gray-500 uppercase mb-1">
+                Message ID
+              </div>
+              <div className="text-sm font-medium text-gray-900">
+                {data.transactionOverview?.pacs8?.transactionId}
+              </div>
             </div>
-            <div className="text-sm font-medium text-gray-900">
-              {data.transactionOverview.transactionId}
+            <div>
+              <div className="text-xs font-medium text-gray-500 uppercase mb-1">
+                Timestamp
+              </div>
+              <div className="text-sm font-medium text-gray-900">
+               {data.transactionOverview?.pacs8?.timestamp &&
+              new Date(data.transactionOverview.pacs8.timestamp).toLocaleString()}
+              </div>
+            </div>
+            <div>
+              <div className="text-xs font-medium text-gray-500 uppercase mb-1">
+                Type
+              </div>
+              <div className="text-sm font-medium text-gray-900">
+                {data.transactionOverview?.pacs8?.transactionType}
+              </div>
+            </div>
+            <div>
+              <div className="text-xs font-medium text-gray-500 uppercase mb-1">
+                Status
+              </div>
+              <span className="inline-flex items-center rounded-md px-2.5 py-1 text-xs font-medium bg-green-50 text-green-700 ring-1 ring-green-200">
+                Completed
+              </span>
             </div>
           </div>
-          <div>
-            <div className="text-xs font-medium text-gray-500 uppercase mb-1">
-              Timestamp
-            </div>
-            <div className="text-sm font-medium text-gray-900">
-              {new Date(data.transactionOverview.timestamp).toLocaleString()}
-            </div>
+        </div>
+
+        {/* PACS.002 - Acknowledgment */}
+        <div className="pt-4 border-t border-gray-100">
+          <div className="text-xs font-semibold text-gray-900 uppercase mb-3 flex items-center gap-2">
+            <span className="underline">PACS.002 - Payment Status Report</span>
+            <span className="px-2 py-0.5 bg-purple-100 text-purple-700 rounded text-xs">Acknowledgment</span>
           </div>
-          <div>
-            <div className="text-xs font-medium text-gray-500 uppercase mb-1">
-              Type
+          <div className="grid grid-cols-4 gap-30">
+            <div>
+              <div className="text-xs font-medium text-gray-500 uppercase mb-1">
+                Message ID
+              </div>
+              <div className="text-sm font-medium text-gray-900">
+                {data.transactionOverview?.pacs2?.transactionId}
+              </div>
             </div>
-            <div className="text-sm font-medium text-gray-900">
-              {data.transactionOverview.transactionType}
+            <div>
+              <div className="text-xs font-medium text-gray-500 uppercase mb-1">
+                Timestamp
+              </div>
+              <div className="text-sm font-medium text-gray-900">
+               {data.transactionOverview?.pacs2?.timestamp &&
+               new Date(data.transactionOverview.pacs2.timestamp).toLocaleString()}
+              </div>
             </div>
-          </div>
-          <div>
-            <div className="text-xs font-medium text-gray-500 uppercase mb-1">
-              Status
+            <div>
+              <div className="text-xs font-medium text-gray-500 uppercase mb-1">
+                Type
+              </div>
+              <div className="text-sm font-medium text-gray-900">
+                {data.transactionOverview?.pacs2?.transactionType}
+              </div>
             </div>
-            <span className="inline-flex items-center rounded-md px-2.5 py-1 text-xs font-medium bg-green-50 text-green-700 ring-1 ring-green-200">
-              Completed
-            </span>
+            <div>
+              <div className="text-xs font-medium text-gray-500 uppercase mb-1">
+                Status
+              </div>
+              <span className="inline-flex items-center rounded-md px-2.5 py-1 text-xs font-medium bg-green-50 text-green-700 ring-1 ring-green-200">
+                Acknowledged
+              </span>
+            </div>
           </div>
         </div>
       </div>
@@ -264,12 +316,6 @@ const TransactionDetailsTab: React.FC<TransactionDetailsTabProps> = ({
               </div>
             </div>
             <div>
-              <div className="text-xs font-medium text-gray-500 uppercase mb-1">
-                Account Type
-              </div>
-              <div className="text-sm text-gray-900">
-                {data.debtorProfile.accountType}
-              </div>
             </div>
             <div>
               <div className="text-xs font-medium text-gray-500 uppercase mb-1">
@@ -280,20 +326,6 @@ const TransactionDetailsTab: React.FC<TransactionDetailsTabProps> = ({
               </div>
             </div>
             <div>
-              <div className="text-xs font-medium text-gray-500 uppercase mb-1">
-                Swift Code
-              </div>
-              <div className="text-sm text-gray-900 font-mono">
-                {data.debtorProfile.swiftCode}
-              </div>
-            </div>
-            <div>
-              <div className="text-xs font-medium text-gray-500 uppercase mb-1">
-                Address
-              </div>
-              <div className="text-sm text-gray-900">
-                {data.debtorProfile.address}
-              </div>
             </div>
           </div>
         </div>
@@ -324,12 +356,6 @@ const TransactionDetailsTab: React.FC<TransactionDetailsTabProps> = ({
               </div>
             </div>
             <div>
-              <div className="text-xs font-medium text-gray-500 uppercase mb-1">
-                Account Type
-              </div>
-              <div className="text-sm text-gray-900">
-                {data.creditorProfile.accountType}
-              </div>
             </div>
             <div>
               <div className="text-xs font-medium text-gray-500 uppercase mb-1">
@@ -337,22 +363,6 @@ const TransactionDetailsTab: React.FC<TransactionDetailsTabProps> = ({
               </div>
               <div className="text-sm text-gray-900">
                 {data.creditorProfile.bank}
-              </div>
-            </div>
-            <div>
-              <div className="text-xs font-medium text-gray-500 uppercase mb-1">
-                Swift Code
-              </div>
-              <div className="text-sm text-gray-900 font-mono">
-                {data.creditorProfile.swiftCode}
-              </div>
-            </div>
-            <div>
-              <div className="text-xs font-medium text-gray-500 uppercase mb-1">
-                Address
-              </div>
-              <div className="text-sm text-gray-900">
-                {data.creditorProfile.address}
               </div>
             </div>
           </div>
@@ -416,47 +426,7 @@ const TransactionDetailsTab: React.FC<TransactionDetailsTabProps> = ({
                     )}
                   </>
                 )}
-                {(amountItem.senderCharges ||
-                  amountItem.intermediaryCharges ||
-                  amountItem.receiverCharges) && (
-                    <>
-                      <div className="border-t border-gray-200 my-2"></div>
-                      {amountItem.senderCharges &&
-                        amountItem.senderCharges.length > 0 && (
-                          <div className="flex justify-between">
-                            <span className="text-sm text-gray-600">
-                              Sender Charges:
-                            </span>
-                            <span className="text-sm font-medium text-gray-900">
-                              ${amountItem.senderCharges[0].amount}
-                            </span>
-                          </div>
-                        )}
-                      {amountItem.intermediaryCharges &&
-                        amountItem.intermediaryCharges.length > 0 && (
-                          <div className="flex justify-between">
-                            <span className="text-sm text-gray-600">
-                              Intermediary Charges:
-                            </span>
-                            <span className="text-sm font-medium text-gray-900">
-                              ${amountItem.intermediaryCharges[0].amount}
-                            </span>
-                          </div>
-                        )}
-                      {amountItem.receiverCharges &&
-                        amountItem.receiverCharges.length > 0 && (
-                          <div className="flex justify-between">
-                            <span className="text-sm text-gray-600">
-                              Receiver Charges:
-                            </span>
-                            <span className="text-sm font-medium text-gray-900">
-                              ${amountItem.receiverCharges[0].amount}
-                            </span>
-                          </div>
-                        )}
-                    </>
-                  )}
-                {amountItem.totalCharges && (
+                {amountItem.totalCharges !== undefined && amountItem.totalCharges !== null && (
                   <>
                     <div className="border-t border-gray-200 my-2"></div>
                     <div className="flex justify-between">
@@ -500,7 +470,8 @@ const TransactionDetailsTab: React.FC<TransactionDetailsTabProps> = ({
                 Transaction Timestamp
               </div>
               <div className="text-sm text-gray-900">
-                {new Date(data.transactionOverview.timestamp).toLocaleString()}
+               {data.transactionOverview?.pacs8?.timestamp &&
+              new Date(data.transactionOverview.pacs8.timestamp).toLocaleString()}
               </div>
             </div>
             {data.settlementDetails.settlementDate && (

--- a/frontend/src/features/cases/components/view/visualizations/transactiondetails/types/types.ts
+++ b/frontend/src/features/cases/components/view/visualizations/transactiondetails/types/types.ts
@@ -1,15 +1,21 @@
 export interface TransactionDetailsDto {
   transactionOverview: {
-    transactionId: string;
-    transactionType: string;
-    timestamp: string;
+    pacs8: {
+      transactionId: string;
+      transactionType: string;
+      timestamp: string;
+    };
+    pacs2: {
+      transactionId: string;
+      transactionType: string;
+      timestamp: string;
+    };
   };
   transactionFlow: {
     debtor: {
       name: string;
       account: {
         iban: string;
-        type: string;
       };
       bank: string;
     };
@@ -21,7 +27,6 @@ export interface TransactionDetailsDto {
       name: string;
       account: {
         iban: string;
-        type: string;
       };
       bankName: string;
     };
@@ -30,49 +35,20 @@ export interface TransactionDetailsDto {
     name: string;
     account: {
       iban: string;
-      type: string;
     };
     bank: string;
-    swiftCode: string;
-    address: string;
-    accountType: string;
   };
   creditorProfile: {
     name: string;
     account: {
       iban: string;
-      type: string;
     };
     bank: string;
-    swiftCode: string;
-    address: string;
-    accountType: string;
   };
   amountAndCurrency: Array<{
     originalAmount?: number;
     exchangeRate?: number;
     convertedAmount?: number;
-    senderCharges?: Array<{
-      amount: number;
-      currency: string;
-      agent: {
-        memberId: string;
-      };
-    }>;
-    intermediaryCharges?: Array<{
-      amount: number;
-      currency: string;
-      agent: {
-        memberId: string;
-      };
-    }>;
-    receiverCharges?: Array<{
-      amount: number;
-      currency: string;
-      agent: {
-        memberId: string;
-      };
-    }>;
     totalCharges?: number;
   }>;
   settlementDetails: {


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?

Transformed the backend response for transaction details to correctly send PACS.002 and PACS.008 data. Also removed unnecessary code and fields.

## Why are we doing this?

To ensure accurate transaction visualization and improve data consistency for frontend consumption. This also simplifies the response structure and enhances maintainability.

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done