### PR TITLE
ci: replace CODEOWNERS individual handles with team handles

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,1 @@
-# Please do not attempt to edit this file without the direct consent from the DevOps team. This file is managed centrally.
-# Contact @scott45
-
-* @Justus-at-Tazama @Sandy-at-Tazama
-/.github/ @scott45
+* @tazama-lf/core-codeowners @tazama-lf/community-codeowners


### PR DESCRIPTION
Replace individual GitHub usernames in .github/CODEOWNERS with the correct team handles. The catch-all rule now uses the org team handles instead of personal accounts.