### PR TITLE
ci: publish migrate Docker image to DockerHub

### DIFF
--- a/.github/workflows/dockerhub-image-build-dual-rc.yml
+++ b/.github/workflows/dockerhub-image-build-dual-rc.yml
@@ -80,6 +80,64 @@ jobs:
         run: |
           curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Release Candidate Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-backend "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/orgs/tazamaorg/repositories>"}]}]}' $SLACK_WEBHOOK_URL
 
+  push_migrate_rc:
+    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
+    name: Push migrate RC Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set ENV variables
+        run: |
+          echo "REPO_NAME=${GITHUB_REPOSITORY#$GITHUB_REPOSITORY_OWNER/}" >> $GITHUB_ENV
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
+        with:
+          images: tazamaorg/${{ env.REPO_NAME }}-migrate
+          tags: |
+            type=raw,value=rc
+
+      - name: Build and push migrate RC Docker image
+        id: push
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          target: migrate
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          secrets: |
+            GH_TOKEN=${{ secrets.GH_TOKEN }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
+        with:
+          subject-name: docker.io/tazamaorg/${{ env.REPO_NAME }}-migrate
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: false  # RC builds: attestation generated locally only; not pushed to sigstore transparency log
+
+      - name: Send Slack Notification
+        continue-on-error: true
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Release Candidate Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-migrate "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/orgs/tazamaorg/repositories>"}]}]}' $SLACK_WEBHOOK_URL
+
   push_frontend_rc:
     if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
     name: Push frontend RC Docker image to Docker Hub

--- a/.github/workflows/dockerhub-image-build-dual.yml
+++ b/.github/workflows/dockerhub-image-build-dual.yml
@@ -85,6 +85,68 @@ jobs:
         run: |
           curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-backend "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/orgs/tazamaorg/repositories>"}]}]}' $SLACK_WEBHOOK_URL
 
+  push_migrate:
+    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
+    name: Push migrate Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set ENV variables
+        run: |
+          echo "REPO_NAME=${GITHUB_REPOSITORY#$GITHUB_REPOSITORY_OWNER/}" >> $GITHUB_ENV
+
+      - name: Get backend package version
+        id: pkg_version
+        run: echo "VERSION=$(node -p "require('./backend/package.json').version")" >> $GITHUB_OUTPUT
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
+        with:
+          images: tazamaorg/${{ env.REPO_NAME }}-migrate
+          tags: |
+            type=raw,value=${{ steps.pkg_version.outputs.VERSION }}
+
+      - name: Build and push migrate Docker image
+        id: push
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          target: migrate
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          secrets: |
+            GH_TOKEN=${{ secrets.GH_TOKEN }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
+        with:
+          subject-name: docker.io/tazamaorg/${{ env.REPO_NAME }}-migrate
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+      - name: Send Slack Notification
+        continue-on-error: true
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-migrate "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/orgs/tazamaorg/repositories>"}]}]}' $SLACK_WEBHOOK_URL
+
   push_frontend:
     if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
     name: Push frontend Docker image to Docker Hub


### PR DESCRIPTION
## Summary

Adds `push_migrate` and `push_migrate_rc` jobs to the DockerHub publish workflows so that `tazamaorg/case-management-system-migrate` is built and pushed alongside the backend and frontend images.

Closes #79

## Problem

The production `run-env` Docker stage uses `gcr.io/distroless/nodejs20-debian11:nonroot` — a shell-less base image. When the CMS stack is deployed from DockerHub images, the `migrate` service attempts to run `sh /home/app/migrate.sh`, but `sh` is not on `$PATH` in a distroless image. The container crashes immediately and the `tazama_cms` / `tazama_dwh` databases are never created, leaving the backend in a permanent crash loop (`PrismaClientInitializationError P1003`).

Local/dev deployments are unaffected because Docker builds from source using the `migrate` stage directly.

## Solution

The `backend/Dockerfile` already defines a `migrate` stage (line 30) built on `node:20-bullseye` which includes `sh`, `postgresql-client`, and `netcat`. This PR adds CI jobs to publish that stage as a separate image:

- `tazamaorg/case-management-system-migrate:<version>` (on merge to `main`)
- `tazamaorg/case-management-system-migrate:rc` (on push to `dev`)

The `full-stack-docker-tazama` compose stack references `tazamaorg/case-management-system-migrate:${TAZAMA_VERSION}` for the `migrate` service.

## Workflow divergence

These workflows now diverge from the central `tazama-lf/workflows` template which only defines `push_backend` and `push_frontend` jobs. This is intentional — the `migrate` image pattern is specific to CMS. Tracked in [tazama-lf/workflows#80](https://github.com/tazama-lf/workflows/issues/80).

## Changes

- `.github/workflows/dockerhub-image-build-dual.yml` — new `push_migrate` job
- `.github/workflows/dockerhub-image-build-dual-rc.yml` — new `push_migrate_rc` job

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced GitHub Actions workflow to automate building and publishing migrate service Docker images to Docker Hub.
  * Added provenance attestations and Slack notifications for release candidate and production releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->