### PR TITLE
fix: update voila version constraints and remove base_url from CMD

### DIFF
--- a/Dockerfile.voila
+++ b/Dockerfile.voila
@@ -20,8 +20,15 @@ EXPOSE 8866
 # backend url (default)
 ENV CASE_MGMT_BACKEND_URL=http://10.10.80.16:3090
 ENV VOILA_PORT=8866
+# CMS frontend origins for frame-ancestors CSP (can be overridden at runtime)
+ENV CMS_FRONTEND_ORIGIN="http://localhost:5175 http://10.10.80.16:5175"
 
 WORKDIR /app/notebooks
 
-# run voila
-CMD ["voila", "--config=/app/notebooks/voila.json", "--Voila.ip=0.0.0.0", "--Voila.port=8866", "--no-browser"]
+# run voila with CSP configured via environment variable
+# Using shell form to allow env var expansion
+CMD voila --config=/app/notebooks/voila.json \
+    --Voila.ip=0.0.0.0 \
+    --Voila.port=8866 \
+    --Voila.tornado_settings="{\"headers\": {\"Content-Security-Policy\": \"frame-ancestors 'self' ${CMS_FRONTEND_ORIGIN}\"}}" \
+    --no-browser

--- a/Dockerfile.voila
+++ b/Dockerfile.voila
@@ -29,6 +29,5 @@ CMD voila /app/notebooks \
 --config=/app/notebooks/voila.json \
 --Voila.ip=0.0.0.0 \
 --Voila.port=8866 \
---Voila.base_url=/voila/ \
 --Voila.tornado_settings="{\"headers\": {\"Content-Security-Policy\": \"frame-ancestors 'self' ${CMS_FRONTEND_ORIGIN}\"}}" \
 --no-browser

--- a/Dockerfile.voila
+++ b/Dockerfile.voila
@@ -18,17 +18,17 @@ RUN pip install --no-cache-dir -r /app/notebooks/requirements.txt
 EXPOSE 8866
 
 # backend url (default)
-ENV CASE_MGMT_BACKEND_URL=http://10.10.80.16:3090
+ENV CASE_MGMT_BACKEND_URL=http://localhost:3090
 ENV VOILA_PORT=8866
 # CMS frontend origins for frame-ancestors CSP (can be overridden at runtime)
-ENV CMS_FRONTEND_ORIGIN="http://localhost:5175 http://10.10.80.16:5175"
+ENV CMS_FRONTEND_ORIGIN="http://localhost:5175"
 
 WORKDIR /app/notebooks
 
-# run voila with CSP configured via environment variable
-# Using shell form to allow env var expansion
-CMD voila --config=/app/notebooks/voila.json \
-    --Voila.ip=0.0.0.0 \
-    --Voila.port=8866 \
-    --Voila.tornado_settings="{\"headers\": {\"Content-Security-Policy\": \"frame-ancestors 'self' ${CMS_FRONTEND_ORIGIN}\"}}" \
-    --no-browser
+CMD voila /app/notebooks \
+--config=/app/notebooks/voila.json \
+--Voila.ip=0.0.0.0 \
+--Voila.port=8866 \
+--Voila.base_url=/voila/ \
+--Voila.tornado_settings="{\"headers\": {\"Content-Security-Policy\": \"frame-ancestors 'self' ${CMS_FRONTEND_ORIGIN}\"}}" \
+--no-browser

--- a/Dockerfile.voila
+++ b/Dockerfile.voila
@@ -17,17 +17,16 @@ RUN pip install --no-cache-dir -r /app/notebooks/requirements.txt
 # expose voila port
 EXPOSE 8866
 
-# backend url (default)
+# Backend URL used by notebooks. Default suits local/host-network dev.
+# In docker-compose, override to the backend service name (e.g. http://backend:3090).
 ENV CASE_MGMT_BACKEND_URL=http://localhost:3090
 ENV VOILA_PORT=8866
-# CMS frontend origins for frame-ancestors CSP (can be overridden at runtime)
+# CMS frontend origins for frame-ancestors CSP (space-separated, can be overridden at runtime)
+# e.g. "http://localhost:5175" or "https://app.example.com https://other.example.com"
 ENV CMS_FRONTEND_ORIGIN="http://localhost:5175"
 
 WORKDIR /app/notebooks
 
-CMD voila /app/notebooks \
---config=/app/notebooks/voila.json \
---Voila.ip=0.0.0.0 \
---Voila.port=8866 \
---Voila.tornado_settings="{\"headers\": {\"Content-Security-Policy\": \"frame-ancestors 'self' ${CMS_FRONTEND_ORIGIN}\"}}" \
---no-browser
+RUN chmod +x /app/notebooks/entrypoint.sh
+
+CMD ["/app/notebooks/entrypoint.sh"]

--- a/notebooks/entrypoint.sh
+++ b/notebooks/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -e
+
+# CMS_FRONTEND_ORIGIN: space-separated list of allowed origins for frame-ancestors CSP
+# e.g. "http://localhost:5175" or "https://app.example.com https://other.example.com"
+if [ -z "$CMS_FRONTEND_ORIGIN" ]; then
+  echo "ERROR: CMS_FRONTEND_ORIGIN must be set and non-empty" >&2
+  exit 1
+fi
+
+# Build valid JSON for Voila.tornado_settings using Python's json module
+TORNADO_SETTINGS=$(python -c "
+import json, os
+origin = os.environ['CMS_FRONTEND_ORIGIN']
+csp = \"frame-ancestors 'self' \" + origin
+settings = {'headers': {'Content-Security-Policy': csp}}
+print(json.dumps(settings))
+")
+
+exec voila /app/notebooks \
+  --config=/app/notebooks/voila.json \
+  --Voila.ip=0.0.0.0 \
+  --Voila.port=8866 \
+  --Voila.tornado_settings="$TORNADO_SETTINGS" \
+  --no-browser

--- a/notebooks/requirements.txt
+++ b/notebooks/requirements.txt
@@ -1,4 +1,4 @@
-voila
+voila>=0.5.0,<0.6.0
 plotly
 pandas
 requests

--- a/notebooks/voila.json
+++ b/notebooks/voila.json
@@ -2,10 +2,7 @@
   "Voila": {
     "ip": "0.0.0.0",
     "port": 8866,
-    "tornado_settings": {
-      "headers": {
-        "Content-Security-Policy": "frame-ancestors 'self' http://localhost:5175 http://10.10.80.16:5175"
-      }
-    }
+    "base_url": "/voila/"
   }
 }
+

--- a/notebooks/voila.json
+++ b/notebooks/voila.json
@@ -1,8 +1,6 @@
 {
   "Voila": {
     "ip": "0.0.0.0",
-    "port": 8866,
-    "base_url": "/voila/"
+    "port": 8866
   }
 }
-


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?

Added CMS_FRONTEND_ORIGIN as an environment variable in the Dockerfile.
Injected the dynamic CSP header using the --Voila.tornado_settings argument.

## Why are we doing this?

Visualizations appear blank in the CMS frontend due to two bugs: First, Voila serves at root / while the ALB expects /voila/, resulting in 404 errors. Second, the hardcoded security policy blocks the AWS CMS origin from embedding Voila in an iframe. This PR fixes both issues by configuring Voila to serve at /voila/ and making the security policy configurable via environment variables, allowing visualizations to render correctly across all environments.

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Default backend URL updated from an internal IP to localhost.

* **New Features**
  * Frontend origin for Content-Security-Policy is now configurable.
  * Container startup moved to an entrypoint that applies runtime CSP settings.

* **Chores**
  * Applied version constraints to the Voila dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->