### PR TITLE
fix: AdminDashboard imports

### DIFF
--- a/frontend/src/features/admin/pages/AdminDashboard.tsx
+++ b/frontend/src/features/admin/pages/AdminDashboard.tsx
@@ -4,12 +4,6 @@ import { PageContainer } from '@/shared/components/ui';
 import ResultsSummary from '@/shared/components/ui/ResultsSummary';
 import ReferenceResultsTable from '../components/ReferenceResultsTable';
 import { useReferenceLookup } from '../hooks/useReferences';
-import React, { useState } from 'react';
-import { PlusIcon } from '@heroicons/react/24/outline';
-import { PageContainer } from '@/shared/components/ui';
-import ResultsSummary from '@/shared/components/ui/ResultsSummary';
-import ReferenceResultsTable from '../components/ReferenceResultsTable';
-import { useReferenceLookup } from '../hooks/useReferences';
 
 const AdminDashboard: React.FC = () => {
   const [txnType, setTxnType] = useState('');


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Removed redundant imports

## Why are we doing this?
A merge conflict caused duplicated imports and needed a hotfix.

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done
