### PR TITLE
feat: added health check endpoint

### DIFF
--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -1,6 +1,6 @@
 import { Body, Controller, Get, HttpCode, Post, UnauthorizedException, UseGuards } from '@nestjs/common';
-import { ApiBearerAuth, ApiBody, ApiOkResponse, ApiOperation, ApiTags, ApiUnauthorizedResponse } from '@nestjs/swagger';
-import { RequireAuthenticated } from '../../decorators/auth.decorator';
+import { ApiBearerAuth, ApiBody, ApiOkResponse, ApiOperation, ApiResponse, ApiTags, ApiUnauthorizedResponse } from '@nestjs/swagger';
+import { RequireAnyClaims, RequireAuthenticated } from '../../decorators/auth.decorator';
 import { LoggerService } from '@tazama-lf/frms-coe-lib';
 import { AuthService } from './auth.service';
 import { User } from '../../decorators/user.decorator';
@@ -9,6 +9,7 @@ import type { AuthenticatedUser } from '../../utils/types/auth.types';
 import { AuthMeResponseDto } from 'src/modules/auth/dto/AuthMeResponse.dto';
 import { LoginRequestDto } from 'src/modules/auth/dto/LoginRequest.dto';
 import { LoginResponseDto } from 'src/modules/auth/dto/LoginResponse.dto';
+import { HealthCheckResponseDTO } from '../triage/dto/triage.dto';
 
 @ApiTags('Auth')
 @ApiBearerAuth('jwt')
@@ -18,6 +19,21 @@ export class AuthController {
     private readonly authService: AuthService,
     private readonly logger: LoggerService,
   ) {}
+
+  @Get('test')
+  @ApiOperation({
+    summary: 'Health check',
+    description: 'Test endpoint to verify triage service is running',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Service is healthy',
+    type: HealthCheckResponseDTO,
+  })
+  @RequireAnyClaims()
+  getTest(): { status: string } {
+    return { status: 'ok' };
+  }
 
   @Post('login')
   @HttpCode(200)

--- a/backend/src/modules/triage/triage.controller.ts
+++ b/backend/src/modules/triage/triage.controller.ts
@@ -1,9 +1,9 @@
 import { Body, Controller, Get, Param, Patch, Req, UseGuards, BadRequestException, HttpCode, HttpStatus } from '@nestjs/common';
 import { TriageService } from './triage.service';
 import { ManualAlertUpdateDTO } from '../alert/dto';
-import { HealthCheckResponseDTO, AlertTriageResponseDTO } from './dto/triage.dto';
+import { AlertTriageResponseDTO } from './dto/triage.dto';
 import { TazamaAuthGuard } from 'src/guards/tazama-auth.guard';
-import { RequireAnyClaims, RequireInvestigatorOrSupervisorRole } from 'src/decorators/auth.decorator';
+import { RequireInvestigatorOrSupervisorRole } from 'src/decorators/auth.decorator';
 import { AuthenticatedRequest } from 'src/utils/types/auth.types';
 import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiBody, ApiParam } from '@nestjs/swagger';
 import { Alert } from '@prisma/client-cms';
@@ -17,21 +17,6 @@ import { TransactionDetailDto } from './dto/transaction-detail.dto';
 @ApiBearerAuth('jwt')
 export class TriageController {
   constructor(private readonly triageService: TriageService) {}
-
-  @Get('test')
-  @ApiOperation({
-    summary: 'Health check',
-    description: 'Test endpoint to verify triage service is running',
-  })
-  @ApiResponse({
-    status: 200,
-    description: 'Service is healthy',
-    type: HealthCheckResponseDTO,
-  })
-  @RequireAnyClaims()
-  getTest(): { status: string } {
-    return { status: 'ok' };
-  }
 
   @Patch(':alertId')
   @RequireInvestigatorOrSupervisorRole()


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Moved the health check endpoint from triage.controller to auth.controller

## Why are we doing this?
The endpoint was previously inaccessible. That was fixed.

## How was it tested?
- [x] Locally
- [ ] Development Environment
- [x] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done
