### PR TITLE
fix: AlertType Filter issue

### DIFF
--- a/backend/src/modules/alert/alert.controller.ts
+++ b/backend/src/modules/alert/alert.controller.ts
@@ -39,6 +39,13 @@ export class AlertController {
     description: 'Filter by type',
   })
   @ApiQuery({
+    name: 'nullAlertType',
+    required: false,
+    type: 'string',
+    description: 'Filter for alerts with no alert type (pass "true")',
+    example: 'true',
+  })
+  @ApiQuery({
     name: 'alertType',
     required: false,
     type: 'string',
@@ -82,13 +89,6 @@ export class AlertController {
     type: 'string',
     description: 'Field to sort by',
     example: 'created_at',
-  })
-  @ApiQuery({
-    name: 'nullAlertType',
-    required: false,
-    type: 'string',
-    description: 'Filter for alerts with no alert type (pass "true")',
-    example: 'true',
   })
   @ApiQuery({
     name: 'sortOrder',

--- a/backend/src/modules/alert/alert.controller.ts
+++ b/backend/src/modules/alert/alert.controller.ts
@@ -106,6 +106,7 @@ export class AlertController {
     @Query('priority') priority?: string,
     @Query('type') type?: string,
     @Query('alertType') alertType?: string,
+    @Query('nullAlertType') nullAlertType?: string,
     @Query('search') search?: string,
     @Query('source') source?: string,
   ): Promise<{
@@ -132,6 +133,7 @@ export class AlertController {
       priority,
       type,
       alertType,
+      nullAlertType: nullAlertType === 'true',
       search,
       source,
       reportStatus,

--- a/backend/src/modules/alert/alert.controller.ts
+++ b/backend/src/modules/alert/alert.controller.ts
@@ -84,6 +84,13 @@ export class AlertController {
     example: 'created_at',
   })
   @ApiQuery({
+    name: 'nullAlertType',
+    required: false,
+    type: 'string',
+    description: 'Filter for alerts with no alert type (pass "true")',
+    example: 'true',
+  })
+  @ApiQuery({
     name: 'sortOrder',
     required: false,
     enum: ['asc', 'desc'],

--- a/backend/src/modules/alert/alert.statistics.service.ts
+++ b/backend/src/modules/alert/alert.statistics.service.ts
@@ -15,6 +15,7 @@ export class AlertStatisticsService {
     priority?: string;
     type?: string;
     alertType?: string;
+    nullAlertType?: boolean;
     search?: unknown;
     source?: string;
     reportStatus?: string;
@@ -39,7 +40,7 @@ export class AlertStatisticsService {
     total: number;
     totalPages: number;
   }> {
-    const { tenantId, priority, type, alertType, search, source, reportStatus, page, limit, sortBy, sortOrder } = params;
+    const { tenantId, priority, type, alertType, nullAlertType, search, source, reportStatus, page, limit, sortBy, sortOrder } = params;
 
     if (!Number.isInteger(page) || page < 1) {
       throw new BadRequestException('Page must be a positive integer');
@@ -77,7 +78,10 @@ export class AlertStatisticsService {
       whereClause.priority = priority.toUpperCase() as Priority;
     }
 
-    if (alertType) {
+    if (nullAlertType) {
+      // Filter for alerts with no alert_type (NULL)
+      whereClause.alert_type = null;
+    } else if (alertType) {
       if (!Object.values(CaseType).includes(alertType.toUpperCase() as CaseType)) {
         throw new BadRequestException(`Invalid alertType: ${alertType}`);
       }

--- a/frontend/src/features/alerts/components/AlertsSearchAndFilters.tsx
+++ b/frontend/src/features/alerts/components/AlertsSearchAndFilters.tsx
@@ -80,7 +80,7 @@ const AlertsSearchAndFilters: React.FC<AlertsSearchAndFiltersProps> = ({
       alertTypes:
         alertTypes && alertTypes.length > 0
           ? alertTypes
-          : ['FRAUD', 'AML', 'FRAUD_AND_AML'],
+          : ['FRAUD', 'AML', 'FRAUD_AND_AML', 'N/A'],
       sources:
         sources && sources.length > 0
           ? sources
@@ -222,7 +222,7 @@ const AlertsSearchAndFilters: React.FC<AlertsSearchAndFiltersProps> = ({
     <div className="bg-white rounded-lg shadow mb-6">
       <div className="p-4">
         <div className="flex flex-col space-y-4 sm:flex-row sm:space-y-0 sm:space-x-4">
-          {}
+          { }
           <div className="flex-1">
             <div className="relative">
               <MagnifyingGlassIcon className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-gray-400" />
@@ -238,7 +238,7 @@ const AlertsSearchAndFilters: React.FC<AlertsSearchAndFiltersProps> = ({
             </div>
           </div>
 
-          {}
+          { }
           <button
             onClick={() => {
               setShowFilters(!showFilters);
@@ -254,7 +254,7 @@ const AlertsSearchAndFilters: React.FC<AlertsSearchAndFiltersProps> = ({
             )}
           </button>
 
-          {}
+          { }
           {hasActiveFilters && (
             <button
               onClick={onClearFilters}
@@ -267,7 +267,7 @@ const AlertsSearchAndFilters: React.FC<AlertsSearchAndFiltersProps> = ({
         </div>
       </div>
 
-      {}
+      { }
       {showFilters && (
         <div className="p-4 bg-gray-50 border-t border-gray-200">
           {loadingOptions ? (
@@ -279,7 +279,7 @@ const AlertsSearchAndFilters: React.FC<AlertsSearchAndFiltersProps> = ({
             </div>
           ) : (
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-6">
-              {}
+              { }
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">
                   Alert Type
@@ -303,7 +303,7 @@ const AlertsSearchAndFilters: React.FC<AlertsSearchAndFiltersProps> = ({
                 </select>
               </div>
 
-              {}
+              { }
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">
                   Priority
@@ -324,7 +324,7 @@ const AlertsSearchAndFilters: React.FC<AlertsSearchAndFiltersProps> = ({
                 </select>
               </div>
 
-              {}
+              { }
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">
                   Source
@@ -345,7 +345,7 @@ const AlertsSearchAndFilters: React.FC<AlertsSearchAndFiltersProps> = ({
                 </select>
               </div>
 
-              {}
+              { }
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">
                   Time Range
@@ -371,7 +371,7 @@ const AlertsSearchAndFilters: React.FC<AlertsSearchAndFiltersProps> = ({
             </div>
           )}
 
-          {}
+          { }
           {showCustomDatePicker && searchFilters.timeRange === 'custom' && (
             <div className="mt-4 p-4 bg-white border border-gray-200 rounded-md">
               <h4 className="text-sm font-medium text-gray-700 mb-3">

--- a/frontend/src/features/alerts/components/AlertsSearchAndFilters.tsx
+++ b/frontend/src/features/alerts/components/AlertsSearchAndFilters.tsx
@@ -181,9 +181,26 @@ const AlertsSearchAndFilters: React.FC<AlertsSearchAndFiltersProps> = ({
     const filter = savedFilters.find((f) => f.id === filterId);
     if (!filter) return;
 
-    onFilterChange('type', filter.alertType);
-    onFilterChange('priority', filter.priority);
-    onFilterChange('source', filter.source);
+    onFilterChange('type', filter.alertType || '');
+    onFilterChange('priority', filter.priority || '');
+    onFilterChange('source', filter.source || '');
+    onFilterChange('timeRange', filter.timeRange || '');
+    onFilterChange('query', ''); // Clear search query
+
+    // Apply custom date range if present
+    if (filter.timeRange === 'custom' && (filter.startDate || filter.endDate)) {
+      onCustomDateRangeChange({
+        startDate: filter.startDate || '',
+        endDate: filter.endDate || '',
+      });
+      setShowCustomDatePicker(true);
+    } else {
+      onCustomDateRangeChange({
+        startDate: '',
+        endDate: '',
+      });
+      setShowCustomDatePicker(false);
+    }
   };
 
   const handleSaveCurrentFilters = async () => {

--- a/frontend/src/features/alerts/components/AlertsSearchAndFilters.tsx
+++ b/frontend/src/features/alerts/components/AlertsSearchAndFilters.tsx
@@ -203,7 +203,7 @@ const AlertsSearchAndFilters: React.FC<AlertsSearchAndFiltersProps> = ({
           endDate: customDateRange.endDate || '',
         }),
       };
-      const savedFilter = await filterService.createFilter(payload);
+      await filterService.createFilter(payload);
 
       success(
         'Filter Created',

--- a/frontend/src/features/alerts/components/AlertsSearchAndFilters.tsx
+++ b/frontend/src/features/alerts/components/AlertsSearchAndFilters.tsx
@@ -181,26 +181,42 @@ const AlertsSearchAndFilters: React.FC<AlertsSearchAndFiltersProps> = ({
     const filter = savedFilters.find((f) => f.id === filterId);
     if (!filter) return;
 
-    onFilterChange('type', filter.alertType || '');
-    onFilterChange('priority', filter.priority || '');
-    onFilterChange('source', filter.source || '');
-    onFilterChange('timeRange', filter.timeRange || '');
-    onFilterChange('query', ''); // Clear search query
+    // Build all filter changes locally first, then apply them in sequence
+    // Using setTimeout to break React's batching and ensure each update sees the previous state
+    onFilterChange('query', ''); // Clear search first
+
+    setTimeout(() => {
+      onFilterChange('type', filter.alertType || '');
+    }, 0);
+
+    setTimeout(() => {
+      onFilterChange('priority', filter.priority || '');
+    }, 10);
+
+    setTimeout(() => {
+      onFilterChange('source', filter.source || '');
+    }, 20);
+
+    setTimeout(() => {
+      onFilterChange('timeRange', filter.timeRange || '');
+    }, 30);
 
     // Apply custom date range if present
-    if (filter.timeRange === 'custom' && (filter.startDate || filter.endDate)) {
-      onCustomDateRangeChange({
-        startDate: filter.startDate || '',
-        endDate: filter.endDate || '',
-      });
-      setShowCustomDatePicker(true);
-    } else {
-      onCustomDateRangeChange({
-        startDate: '',
-        endDate: '',
-      });
-      setShowCustomDatePicker(false);
-    }
+    setTimeout(() => {
+      if (filter.timeRange === 'custom' && (filter.startDate || filter.endDate)) {
+        onCustomDateRangeChange({
+          startDate: filter.startDate || '',
+          endDate: filter.endDate || '',
+        });
+        setShowCustomDatePicker(true);
+      } else {
+        onCustomDateRangeChange({
+          startDate: '',
+          endDate: '',
+        });
+        setShowCustomDatePicker(false);
+      }
+    }, 40);
   };
 
   const handleSaveCurrentFilters = async () => {

--- a/frontend/src/features/alerts/components/__tests__/AlertsSearchAndFilters.test.tsx
+++ b/frontend/src/features/alerts/components/__tests__/AlertsSearchAndFilters.test.tsx
@@ -194,9 +194,12 @@ describe('AlertsSearchAndFilters', () => {
       .closest('select') as HTMLSelectElement;
     fireEvent.change(savedSelect, { target: { value: '1' } });
 
-    expect(onFilterChange).toHaveBeenCalledWith('type', 'FRAUD');
-    expect(onFilterChange).toHaveBeenCalledWith('priority', 'URGENT');
-    expect(onFilterChange).toHaveBeenCalledWith('source', 'System A');
+    // Wait for async setTimeout calls to complete
+    await waitFor(() => {
+      expect(onFilterChange).toHaveBeenCalledWith('type', 'FRAUD');
+      expect(onFilterChange).toHaveBeenCalledWith('priority', 'URGENT');
+      expect(onFilterChange).toHaveBeenCalledWith('source', 'System A');
+    }, { timeout: 100 });
   });
 
   it('renders filter dropdowns with provided options', async () => {

--- a/frontend/src/features/alerts/components/__tests__/alertsComponentsIndex.test.ts
+++ b/frontend/src/features/alerts/components/__tests__/alertsComponentsIndex.test.ts
@@ -1,5 +1,52 @@
 import { describe, it, expect, vi } from 'vitest';
 
+// Mock React Router to prevent initialization issues
+vi.mock('react-router-dom', () => ({
+  useNavigate: vi.fn(),
+  useLocation: vi.fn(() => ({ pathname: '/' })),
+  Link: vi.fn(({ children }) => children),
+  NavLink: vi.fn(({ children }) => children),
+  Outlet: vi.fn(() => null),
+}));
+
+// Mock React Query
+vi.mock('@tanstack/react-query', () => ({
+  QueryClient: vi.fn(),
+  QueryClientProvider: vi.fn(({ children }) => children),
+  useQuery: vi.fn(),
+  useMutation: vi.fn(),
+  useQueryClient: vi.fn(),
+}));
+
+// Mock API client and storage utilities first
+vi.mock('@/shared/services/apiClient', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock('@/shared/utils/storage', () => ({
+  resetData: vi.fn(),
+  getData: vi.fn(),
+  setData: vi.fn(),
+}));
+
+// Mock shared providers
+vi.mock('@/shared/providers/NotificationProvider', () => ({
+  NotificationProvider: vi.fn(({ children }) => children),
+  useNotifications: vi.fn(() => ({
+    notifications: [],
+    addNotification: vi.fn(),
+  })),
+}));
+
+vi.mock('@/shared/providers/QueryProvider', () => ({
+  QueryProvider: vi.fn(({ children }) => children),
+}));
+
 // Mock the problematic service dependencies before importing components
 vi.mock('../../../cases/services/filterService', () => ({
   filterService: {
@@ -27,10 +74,10 @@ describe('alerts components barrel exports', () => {
   it('exports AlertsTable', async () => {
     const mod = await import('../index');
     expect(mod.AlertsTable).toBeDefined();
-  });
+  }, 10000);
 
   it('exports AlertsSearchAndFilters', async () => {
     const mod = await import('../index');
     expect(mod.AlertsSearchAndFilters).toBeDefined();
-  });
+  }, 10000);
 });

--- a/frontend/src/features/alerts/components/__tests__/alertsComponentsIndex.test.ts
+++ b/frontend/src/features/alerts/components/__tests__/alertsComponentsIndex.test.ts
@@ -1,13 +1,36 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock the problematic service dependencies before importing components
+vi.mock('../../../cases/services/filterService', () => ({
+  filterService: {
+    getFilters: vi.fn(),
+    createFilter: vi.fn(),
+  },
+}));
+
+vi.mock('../../../auth/services/authService', () => ({
+  default: {
+    getToken: vi.fn(),
+    getUser: vi.fn(),
+    login: vi.fn(),
+    logout: vi.fn(),
+  },
+}));
+
+vi.mock('@/shared/providers/ToastProvider', () => ({
+  useToast: vi.fn(() => ({
+    showToast: vi.fn(),
+  })),
+}));
 
 describe('alerts components barrel exports', () => {
   it('exports AlertsTable', async () => {
     const mod = await import('../index');
     expect(mod.AlertsTable).toBeDefined();
-  }, 10000);
+  });
 
   it('exports AlertsSearchAndFilters', async () => {
     const mod = await import('../index');
     expect(mod.AlertsSearchAndFilters).toBeDefined();
-  }, 10000);
+  });
 });

--- a/frontend/src/features/alerts/hooks/__tests__/useAlertsQuery.test.ts
+++ b/frontend/src/features/alerts/hooks/__tests__/useAlertsQuery.test.ts
@@ -1,4 +1,4 @@
-﻿import React from 'react';
+import React from 'react';
 import { renderHook, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';

--- a/frontend/src/features/alerts/hooks/__tests__/useAlertsQuery.test.ts
+++ b/frontend/src/features/alerts/hooks/__tests__/useAlertsQuery.test.ts
@@ -1,4 +1,4 @@
-﻿import React from 'react';
+import React from 'react';
 import { renderHook, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -500,7 +500,7 @@ describe('useAlertsQuery', () => {
 
       expect(result.current.filterOptions).toEqual({
         priorities: ['NEW', 'URGENT', 'CRITICAL', 'BREACH'],
-        alertTypes: ['FRAUD', 'AML', 'FRAUD_AND_AML'],
+        alertTypes: ['FRAUD', 'AML', 'FRAUD_AND_AML', 'N/A'],
         sources: ['REST API', 'NATS'],
       });
       expect(result.current.isLoading).toBe(false);

--- a/frontend/src/features/alerts/hooks/__tests__/useAlertsQuery.test.ts
+++ b/frontend/src/features/alerts/hooks/__tests__/useAlertsQuery.test.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+﻿import React from 'react';
 import { renderHook, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';

--- a/frontend/src/features/alerts/hooks/useAlertsQuery.ts
+++ b/frontend/src/features/alerts/hooks/useAlertsQuery.ts
@@ -282,7 +282,7 @@ export const useAlertFilterOptions = (): {
 } => {
   const filterOptions = {
     priorities: ['NEW', 'URGENT', 'CRITICAL', 'BREACH'],
-    alertTypes: ['FRAUD', 'AML', 'FRAUD_AND_AML'],
+    alertTypes: ['FRAUD', 'AML', 'FRAUD_AND_AML', 'N/A'],
     sources: ['REST API', 'NATS'],
   };
 

--- a/frontend/src/features/alerts/services/triageservice.ts
+++ b/frontend/src/features/alerts/services/triageservice.ts
@@ -9,6 +9,7 @@ import type {
   AlertsFilter,
   ActionHistory,
   TransactionDataResponseDTO,
+  TransactionDetailRecordDTO,
 } from '../types/triage.types';
 
 class TriageService {
@@ -59,7 +60,14 @@ class TriageService {
 
     if (filters.priority) params.append('priority', filters.priority);
     if (filters.type) params.append('type', filters.type);
-    if (filters.alertType) params.append('alertType', filters.alertType);
+    // Handle N/A - indicates alerts with no alert type
+    if (filters.alertType) {
+      if (filters.alertType === 'N/A') {
+        params.append('nullAlertType', 'true');
+      } else {
+        params.append('alertType', filters.alertType);
+      }
+    }
     if (filters.source) params.append('source', filters.source);
     if (filters.search) params.append('search', filters.search);
     params.append('reportStatus', filters.reportStatus ?? 'ALRT');


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Added Alertype 'N/A' in filter as well.
## Why are we doing this?
As a Change Request, this is added so all the alerts with no alert type can be shown on the Alert Dashboard by filter.
## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "N/A" as a selectable alert type so users can filter and view alerts with no assigned type.
  * API now supports returning alerts with no type when "N/A" is selected.

* **UX Improvements**
  * Applying a saved filter now clears the search box and restores type, priority, source, time range, and custom date picker state.

* **Tests**
  * Updated tests and mocks to cover the new "N/A" option and filtering behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tazama-lf/case-management-system/pull/128)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->