### PR TITLE
fix: display investigator and tenant user names correctly in CMS views

### DIFF
--- a/backend/src/modules/report/report.service.ts
+++ b/backend/src/modules/report/report.service.ts
@@ -696,7 +696,7 @@ export class ReportsService {
 
         return {
           investigatorId: caseOwnerUserId,
-          investigator: `User ${caseOwnerUserId}`,
+          investigator: caseOwnerUserId,
           role: 'Investigator',
           totalCases,
           activeCases,
@@ -1129,7 +1129,7 @@ export class ReportsService {
       ageDays: case_.ageDays,
       priority: case_.priority,
       userId: case_.case_owner_user_id ?? null,
-      investigator: case_.case_owner_user_id ? `User ${case_.case_owner_user_id}` : 'Unassigned',
+      investigator: case_.case_owner_user_id ?? 'Unassigned',
     }));
 
     return {

--- a/backend/src/modules/report/report.service.ts
+++ b/backend/src/modules/report/report.service.ts
@@ -1121,7 +1121,7 @@ export class ReportsService {
       });
     });
 
-    const caseDetails = casesWithAge.slice(0, 5).map((case_) => ({
+    const caseDetails = casesWithAge.map((case_) => ({
       caseId: case_.case_id,
       type: case_.case_type ?? 'NONE',
       status: this.formatStatusName(case_.status),

--- a/backend/src/modules/task/services/task-lifecycle.service.ts
+++ b/backend/src/modules/task/services/task-lifecycle.service.ts
@@ -443,13 +443,14 @@ export class TaskLifecycleService {
       this.logger.log(`Fetching user details for userId: ${userId} in tenant: ${tenantName}`, TaskLifecycleService.name);
       if (userId) {
         const investigatorList = await this.userService.getUsersByRole(token, 'CMS_INVESTIGATOR', tenantName);
-
+        this.logger.log(`Fetched ${investigatorList.length} investigators`, TaskLifecycleService.name);
         const investigator = investigatorList.find((i) => i.id === userId);
 
         if (investigator) {
           return `${investigator.firstName} ${investigator.lastName}`;
         } else {
           const supervisorList = await this.userService.getUsersByRole(token, 'CMS_SUPERVISOR', tenantName);
+          this.logger.log(`Fetched ${supervisorList.length} supervisors`, TaskLifecycleService.name);
           const isSupervisor = supervisorList.find((s) => s.id === userId);
           if (isSupervisor) {
             return `${isSupervisor.firstName} ${isSupervisor.lastName}`;

--- a/backend/src/modules/task/services/task-lifecycle.service.ts
+++ b/backend/src/modules/task/services/task-lifecycle.service.ts
@@ -103,8 +103,8 @@ export class TaskLifecycleService {
       return { updatedTask, updatedCase };
     });
 
-    const { token } = user;
-    const fullname = await this.fetchUserDetails(token.tokenString, tenantId, assignedUserId);
+    const { token, tenantName } = user;
+    const fullname = await this.fetchUserDetails(token.tokenString, tenantName, assignedUserId);
 
     await this.loggingOrchestrationService.logActionsWithHistory(
       {
@@ -211,8 +211,8 @@ export class TaskLifecycleService {
       return { updatedTask, updatedCase };
     });
 
-    const { token } = user;
-    const fullname = await this.fetchUserDetails(token.tokenString, tenantId, assignedUserId);
+    const { token, tenantName } = user;
+    const fullname = await this.fetchUserDetails(token.tokenString, tenantName, assignedUserId);
 
     await this.loggingOrchestrationService.logActionsWithHistory(
       {
@@ -331,8 +331,8 @@ export class TaskLifecycleService {
       const errorStack = e instanceof Error ? e.stack : undefined;
       this.logger.warn(`Failed notifications for unassign: ${errorMessage}`, errorStack, TaskLifecycleService.name);
     }
-    const { token } = user;
-    const fullname = await this.fetchUserDetails(token.tokenString, tenantId, existingTask.assigned_user_id);
+    const { token, tenantName } = user;
+    const fullname = await this.fetchUserDetails(token.tokenString, tenantName, existingTask.assigned_user_id);
 
     await this.loggingOrchestrationService.logActionsWithHistory(
       {

--- a/backend/src/modules/task/services/task-lifecycle.service.ts
+++ b/backend/src/modules/task/services/task-lifecycle.service.ts
@@ -12,6 +12,7 @@ import { CaseRepository } from 'src/modules/repository/case.repository';
 import { setTimeout } from 'node:timers/promises';
 import { RbacService, EndpointKey } from 'src/utils/rbac/rbacHelper';
 import type { AuthenticatedUser } from 'src/utils/types/auth.types';
+import { UserService } from 'src/modules/user/user.service';
 
 @Injectable()
 export class TaskLifecycleService {
@@ -25,6 +26,7 @@ export class TaskLifecycleService {
     private readonly flowableService: FlowableService,
     private readonly notificationService: NotificationService,
     private readonly loggingOrchestrationService: LoggingOrchestrationService,
+    private readonly userService: UserService,
   ) {}
 
   async assignTaskToInvestigator(
@@ -101,12 +103,15 @@ export class TaskLifecycleService {
       return { updatedTask, updatedCase };
     });
 
+    const { token } = user;
+    const fullname = await this.fetchUserDetails(token.tokenString, tenantId, assignedUserId);
+
     await this.loggingOrchestrationService.logActionsWithHistory(
       {
         userId,
         actionPerformed: isInvestigationTask
-          ? `Assigned task ${taskId} to investigator ${assignedUserId} and updated case ${existingTask.case_id} to ASSIGNED`
-          : `Assigned task ${taskId} to user ${assignedUserId}`,
+          ? `Assigned task ${taskId} to investigator ${fullname ?? assignedUserId} and updated case ${existingTask.case_id} to ASSIGNED`
+          : `Assigned task ${taskId} to user ${fullname ?? assignedUserId}`,
         entityName: 'TaskService',
         operation: 'assignTaskToInvestigator',
         outcome: Outcome.SUCCESS,
@@ -206,10 +211,13 @@ export class TaskLifecycleService {
       return { updatedTask, updatedCase };
     });
 
+    const { token } = user;
+    const fullname = await this.fetchUserDetails(token.tokenString, tenantId, assignedUserId);
+
     await this.loggingOrchestrationService.logActionsWithHistory(
       {
         userId: assignedUserId,
-        actionPerformed: `Task ${taskId} reassigned to investigator ${assignedUserId}`,
+        actionPerformed: `Task ${taskId} reassigned to investigator ${fullname ?? assignedUserId}`,
         entityName: 'TaskService',
         operation: 'retrieveTask',
         outcome: Outcome.SUCCESS,
@@ -323,11 +331,13 @@ export class TaskLifecycleService {
       const errorStack = e instanceof Error ? e.stack : undefined;
       this.logger.warn(`Failed notifications for unassign: ${errorMessage}`, errorStack, TaskLifecycleService.name);
     }
+    const { token } = user;
+    const fullname = await this.fetchUserDetails(token.tokenString, tenantId, existingTask.assigned_user_id);
 
     await this.loggingOrchestrationService.logActionsWithHistory(
       {
         userId: actorUserId,
-        actionPerformed: `Unassigned task ${taskId} from user ${existingTask.assigned_user_id}.`,
+        actionPerformed: `Unassigned task ${taskId} from user ${fullname ?? existingTask.assigned_user_id}.`,
         entityName: 'TaskService',
         operation: 'unassignTask',
         outcome: Outcome.SUCCESS,
@@ -425,6 +435,33 @@ export class TaskLifecycleService {
       }
       await setTimeout(1000 * attempt);
       await this.retry(fn, maxRetries, attempt + 1);
+    }
+  }
+
+  private async fetchUserDetails(token: string, tenantName: string, userId?: string): Promise<string | undefined> {
+    try {
+      this.logger.log(`Fetching user details for userId: ${userId} in tenant: ${tenantName}`, TaskLifecycleService.name);
+      if (userId) {
+        const investigatorList = await this.userService.getUsersByRole(token, 'CMS_INVESTIGATOR', tenantName);
+
+        const investigator = investigatorList.find((i) => i.id === userId);
+
+        if (investigator) {
+          return `${investigator.firstName} ${investigator.lastName}`;
+        } else {
+          const supervisorList = await this.userService.getUsersByRole(token, 'CMS_SUPERVISOR', tenantName);
+          const isSupervisor = supervisorList.find((s) => s.id === userId);
+          if (isSupervisor) {
+            return `${isSupervisor.firstName} ${isSupervisor.lastName}`;
+          }
+        }
+      } else {
+        return undefined;
+      }
+    } catch (e) {
+      const errorMessage = e instanceof Error ? e.message : String(e);
+      const errorStack = e instanceof Error ? e.stack : undefined;
+      this.logger.warn(`Failed to fetch user details: ${errorMessage}`, errorStack, TaskLifecycleService.name);
     }
   }
 

--- a/backend/src/modules/task/task.module.ts
+++ b/backend/src/modules/task/task.module.ts
@@ -12,6 +12,7 @@ import { EventLogModule } from '../event_log/eventLog.module';
 import { TaskHistoryModule } from '../task_history/taskHistory.module';
 import { CaseHistoryModule } from '../case_history/caseHistory.module';
 import { LoggingOrchestrationModule } from '../logging-orchestration/logging-orchestration.module';
+import { UserModule } from '../user/user.module';
 
 @Module({
   imports: [
@@ -25,6 +26,7 @@ import { LoggingOrchestrationModule } from '../logging-orchestration/logging-orc
     TaskHistoryModule,
     CaseHistoryModule,
     LoggingOrchestrationModule,
+    UserModule,
   ],
   providers: [TaskService, TaskLifecycleService],
   exports: [TaskService],

--- a/backend/test/task-lifecycle.service.spec.ts
+++ b/backend/test/task-lifecycle.service.spec.ts
@@ -14,6 +14,7 @@ import { TaskStatus, CaseStatus } from '@prisma/client-cms';
 import { TASK_NAMES } from '../src/constants/case.constants';
 import { RbacService, EndpointKey } from '../src/utils/rbac/rbacHelper';
 import { AuthenticatedUser } from '../src/utils/types/auth.types';
+import { UserService } from '../src/modules/user/user.service';
 import * as timersPromises from 'node:timers/promises';
 
 jest.mock('node:timers/promises', () => ({ setTimeout: jest.fn().mockResolvedValue(undefined) }));
@@ -72,6 +73,10 @@ describe('TaskLifecycleService', () => {
 
   const mockNotificationService = {
     sendNotification: jest.fn(),
+  };
+
+  const mockUserService = {
+    getUsersByRole: jest.fn().mockResolvedValue([]),
   };
 
   const mockLoggingService = {
@@ -146,6 +151,10 @@ describe('TaskLifecycleService', () => {
         {
           provide: NotificationService,
           useValue: mockNotificationService,
+        },
+        {
+          provide: UserService,
+          useValue: mockUserService,
         },
         {
           provide: LoggingOrchestrationService,

--- a/frontend/src/features/cases/components/modals/GenerateInvestigationReportModal.tsx
+++ b/frontend/src/features/cases/components/modals/GenerateInvestigationReportModal.tsx
@@ -188,18 +188,18 @@ const GenerateInvestigationReportModal: React.FC<
       }
     }, []);
 
-    const getAssigneeFullName = (assigneeName?: string, assignee?: string) => {
+    const getAssigneeFullName = (assignee?: string) => {
       const inv = investigators.find(
-        (i) => i.id === assigneeName || i.id === assignee,
+        (i) => i.id === assignee,
       );
       if (inv) return `${inv.firstName} ${inv.lastName}`;
 
       const sup = supervisors.find(
-        (i) => i.id === assigneeName || i.id === assignee,
+        (i) => i.id === assignee,
       );
       if (sup) return `${sup.firstName} ${sup.lastName}`;
 
-      return '';
+      return 'N/A';
     };
 
     useEffect(() => {

--- a/frontend/src/features/cases/components/modals/GenerateInvestigationReportModal.tsx
+++ b/frontend/src/features/cases/components/modals/GenerateInvestigationReportModal.tsx
@@ -172,35 +172,7 @@ const GenerateInvestigationReportModal: React.FC<
     const [commentsLoaded, setCommentsLoaded] = useState(false);
     const [notesLoaded, setNotesLoaded] = useState(false);
     const [submittedDate, setSubmittedDate] = useState<string>('N/A');
-    const {
-      investigators,
-      supervisors,
-      fetchInvestigatorsList,
-      fetchSupervisorsList,
-    } = useInvestigatorSupervisorList();
-
-    useEffect(() => {
-      if (investigators.length === 0) {
-        fetchInvestigatorsList();
-      }
-      if (supervisors.length === 0) {
-        fetchSupervisorsList();
-      }
-    }, []);
-
-    const getAssigneeFullName = (assignee?: string) => {
-      const inv = investigators.find(
-        (i) => i.id === assignee,
-      );
-      if (inv) return `${inv.firstName} ${inv.lastName}`;
-
-      const sup = supervisors.find(
-        (i) => i.id === assignee,
-      );
-      if (sup) return `${sup.firstName} ${sup.lastName}`;
-
-      return 'N/A';
-    };
+    const { getAssigneeFullName } = useInvestigatorSupervisorList();
 
     useEffect(() => {
       hasFetchedRef.current = false;

--- a/frontend/src/features/cases/components/modals/GenerateInvestigationReportModal.tsx
+++ b/frontend/src/features/cases/components/modals/GenerateInvestigationReportModal.tsx
@@ -23,6 +23,7 @@ import {
 import type { TaskComment } from '../../services/commentService';
 import { formatDate } from '@/shared/utils/dateUtils';
 import type { TDocumentDefinitions } from 'pdfmake/interfaces';
+import { useInvestigatorSupervisorList } from '../../hooks/useInvestigatorSupervisorList';
 
 interface EvidenceCategory {
   type: string;
@@ -152,7 +153,6 @@ const GenerateInvestigationReportModal: React.FC<
     const [step, setStep] = useState<'initial' | 'generated'>('initial');
     const [isGenerating, setIsGenerating] = useState(false);
     const [isFinalizing, setIsFinalizing] = useState(false);
-    const [investigatorName, setInvestigatorName] = useState<string>('N/A');
     const [isApproved, setIsApproved] = useState(false);
     const [tasksCompleted, setTasksCompleted] = useState(false);
     const [incompleteTasks, setIncompleteTasks] = useState<string[]>([]);
@@ -172,6 +172,35 @@ const GenerateInvestigationReportModal: React.FC<
     const [commentsLoaded, setCommentsLoaded] = useState(false);
     const [notesLoaded, setNotesLoaded] = useState(false);
     const [submittedDate, setSubmittedDate] = useState<string>('N/A');
+    const {
+      investigators,
+      supervisors,
+      fetchInvestigatorsList,
+      fetchSupervisorsList,
+    } = useInvestigatorSupervisorList();
+
+    useEffect(() => {
+      if (investigators.length === 0) {
+        fetchInvestigatorsList();
+      }
+      if (supervisors.length === 0) {
+        fetchSupervisorsList();
+      }
+    }, []);
+
+    const getAssigneeFullName = (assigneeName?: string, assignee?: string) => {
+      const inv = investigators.find(
+        (i) => i.id === assigneeName || i.id === assignee,
+      );
+      if (inv) return `${inv.firstName} ${inv.lastName}`;
+
+      const sup = supervisors.find(
+        (i) => i.id === assigneeName || i.id === assignee,
+      );
+      if (sup) return `${sup.firstName} ${sup.lastName}`;
+
+      return '';
+    };
 
     useEffect(() => {
       hasFetchedRef.current = false;
@@ -219,12 +248,10 @@ const GenerateInvestigationReportModal: React.FC<
       try {
         const {
           supervisorComments,
-          investigatorName,
           investigationNotes,
           submittedDate,
         } = await fetchCasesAndEvidence(caseId, latestInvestigateTask.task_id);
         setSupervisorComments(supervisorComments);
-        setInvestigatorName(investigatorName);
         setSubmittedDate(submittedDate);
         setInvestigationNotes(investigationNotes);
       } catch (err) {
@@ -409,7 +436,7 @@ const GenerateInvestigationReportModal: React.FC<
                 {
                   text: [
                     { text: 'Investigator: ', bold: true },
-                    investigatorName,
+                    getAssigneeFullName(latestInvestigateTask?.assigned_user_id),
                   ],
                   margin: [0, 0, 0, 5],
                 },
@@ -918,7 +945,7 @@ const GenerateInvestigationReportModal: React.FC<
                       <span className="font-medium text-gray-700">
                         Investigator:
                       </span>
-                      <span className="text-gray-900">{investigatorName}</span>
+                      <span className="text-gray-900">{getAssigneeFullName(latestInvestigateTask?.assigned_user_id)}</span>
                     </div>
                     <div className="flex items-center gap-2">
                       <span className="font-medium text-gray-700">
@@ -1120,8 +1147,8 @@ const GenerateInvestigationReportModal: React.FC<
                     onClick={handleApproveClick}
                     disabled={isFinalizing || isApproved}
                     className={`inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md ${isApproved
-                        ? 'text-gray-400 bg-gray-100 border border-gray-200 cursor-not-allowed'
-                        : 'text-white bg-green-600 hover:bg-green-700 disabled:bg-green-400 disabled:cursor-not-allowed'
+                      ? 'text-gray-400 bg-gray-100 border border-gray-200 cursor-not-allowed'
+                      : 'text-white bg-green-600 hover:bg-green-700 disabled:bg-green-400 disabled:cursor-not-allowed'
                       }`}
                   >
                     {isFinalizing ? (

--- a/frontend/src/features/cases/components/modals/SarStrFilingModal.tsx
+++ b/frontend/src/features/cases/components/modals/SarStrFilingModal.tsx
@@ -19,6 +19,7 @@ import {
 import { useAuth } from '@/features/auth';
 import DeleteEvidenceModal from '../modals/DeleteEvidenceModal';
 import { formatDate } from '@/shared/utils/dateUtils';
+import { useInvestigatorSupervisorList } from '../../hooks/useInvestigatorSupervisorList';
 
 const CompleteTaskModal = lazy(
   async () => await import('../modals/CompleteTaskModal'),
@@ -50,6 +51,7 @@ const SarStrFilingModal: React.FC<SarStrFilingModalProps> = ({
   const { success, error } = useToast();
   const [completeTaskModalOpen, setCompleteTaskModalOpen] = useState(false);
   const { hasComplianceOfficerRole, hasSupervisorRole } = useAuth();
+  const { getAssigneeFullName } = useInvestigatorSupervisorList();
   const [downloadingId, setDownloadingId] = useState<string | null>(null);
   const [evidenceToDelete, setEvidenceToDelete] = React.useState<{
     id: string;
@@ -410,11 +412,10 @@ const SarStrFilingModal: React.FC<SarStrFilingModalProps> = ({
                 <div className="mt-1">
                   <div className="flex justify-between items-center">
                     <span
-                      className={`text-xs ${
-                        sarRemarks.length === 500
-                          ? 'text-red-500'
-                          : 'text-gray-500'
-                      }`}
+                      className={`text-xs ${sarRemarks.length === 500
+                        ? 'text-red-500'
+                        : 'text-gray-500'
+                        }`}
                     >
                       {sarRemarks.length}/500
                     </span>
@@ -490,7 +491,7 @@ const SarStrFilingModal: React.FC<SarStrFilingModalProps> = ({
                             )}
                             <p className="text-xs text-gray-500 mt-1.5">
                               Uploaded: {formatDate(evidence.uploadedAt)} by{' '}
-                              {evidence.uploadedBy}
+                              {getAssigneeFullName(evidence.uploadedBy)}
                             </p>
                           </div>
                           {/* <div className="ml-3 flex items-center gap-2">

--- a/frontend/src/features/cases/components/modals/__tests__/GenerateInvestigationReportModal.test.tsx
+++ b/frontend/src/features/cases/components/modals/__tests__/GenerateInvestigationReportModal.test.tsx
@@ -7,6 +7,9 @@ import GenerateInvestigationReportModal, {
 } from '../GenerateInvestigationReportModal';
 import { useNotifications } from '@/shared/providers/NotificationProvider';
 
+const mockFetchInvestigatorsList = vi.fn();
+const mockFetchSupervisorsList = vi.fn();
+
 vi.mock('@/shared/providers/NotificationProvider');
 vi.mock('../../../../reports/services/reportsService', () => ({
   default: {
@@ -32,6 +35,20 @@ vi.mock('../../../utils/investigationUtils', () => ({
     investigatorName: 'John Doe',
     investigationNotes: 'Some investigation notes',
     submittedDate: '2024-01-15',
+  }),
+}));
+vi.mock('../../../hooks/useInvestigatorSupervisorList', () => ({
+  useInvestigatorSupervisorList: () => ({
+    investigators: [
+      {
+        id: 'user-1',
+        firstName: 'John',
+        lastName: 'Doe',
+      },
+    ],
+    supervisors: [],
+    fetchInvestigatorsList: mockFetchInvestigatorsList,
+    fetchSupervisorsList: mockFetchSupervisorsList,
   }),
 }));
 vi.mock('pdfmake/build/pdfmake', () => ({
@@ -67,6 +84,7 @@ const mockTasks = [
     name: 'Investigate AML',
     status: 'STATUS_30_COMPLETED',
     created_at: '2024-01-01T00:00:00Z',
+    assigned_user_id: 'user-1',
   },
 ];
 
@@ -91,6 +109,7 @@ describe('GenerateInvestigationReportModal', () => {
         name: 'Investigate AML',
         status: 'STATUS_30_COMPLETED',
         created_at: '2024-01-01T00:00:00Z',
+        assigned_user_id: 'user-1',
       },
     ]);
     // Re-set investigationUtils mocks after clearAllMocks

--- a/frontend/src/features/cases/components/modals/__tests__/GenerateInvestigationReportModal.test.tsx
+++ b/frontend/src/features/cases/components/modals/__tests__/GenerateInvestigationReportModal.test.tsx
@@ -9,6 +9,10 @@ import { useNotifications } from '@/shared/providers/NotificationProvider';
 
 const mockFetchInvestigatorsList = vi.fn();
 const mockFetchSupervisorsList = vi.fn();
+const mockGetAssigneeFullName = vi.fn((assignee?: string) => {
+  if (assignee === 'user-1') return 'John Doe';
+  return '';
+});
 
 vi.mock('@/shared/providers/NotificationProvider');
 vi.mock('../../../../reports/services/reportsService', () => ({
@@ -39,14 +43,7 @@ vi.mock('../../../utils/investigationUtils', () => ({
 }));
 vi.mock('../../../hooks/useInvestigatorSupervisorList', () => ({
   useInvestigatorSupervisorList: () => ({
-    investigators: [
-      {
-        id: 'user-1',
-        firstName: 'John',
-        lastName: 'Doe',
-      },
-    ],
-    supervisors: [],
+    getAssigneeFullName: mockGetAssigneeFullName,
     fetchInvestigatorsList: mockFetchInvestigatorsList,
     fetchSupervisorsList: mockFetchSupervisorsList,
   }),

--- a/frontend/src/features/cases/components/view/InvestigationsSummaryTab.tsx
+++ b/frontend/src/features/cases/components/view/InvestigationsSummaryTab.tsx
@@ -50,12 +50,7 @@ const InvestigationSummaryTab: React.FC<InvestigationSummaryTabProps> = ({
   refreshKey,
   task,
 }) => {
-  const {
-    investigators,
-    supervisors,
-    fetchInvestigatorsList,
-    fetchSupervisorsList,
-  } = useInvestigatorSupervisorList();
+  const { getAssigneeFullName } = useInvestigatorSupervisorList();
   const [currentTaskId, setCurrentTaskId] = useState<number | null>(null);
   const { success, error: toastError } = useToast();
   const [caseDetails, setCaseDetails] = useState<Case | null>(null);
@@ -97,28 +92,6 @@ const InvestigationSummaryTab: React.FC<InvestigationSummaryTabProps> = ({
     caseId: task.case_id,
   });
 
-  useEffect(() => {
-    if (investigators.length === 0) {
-      fetchInvestigatorsList();
-    }
-    if (supervisors.length === 0) {
-      fetchSupervisorsList();
-    }
-  }, []);
-
-  const getAssigneeFullName = (assignee?: string) => {
-    const inv = investigators.find(
-      (i) => i.id === assignee,
-    );
-    if (inv) return `${inv.firstName} ${inv.lastName}`;
-
-    const sup = supervisors.find(
-      (i) => i.id === assignee,
-    );
-    if (sup) return `${sup.firstName} ${sup.lastName}`;
-
-    return 'N/A';
-  };
 
   const loadEvidence = React.useCallback(async (): Promise<void> => {
     if (!currentTaskId) return;

--- a/frontend/src/features/cases/components/view/InvestigationsSummaryTab.tsx
+++ b/frontend/src/features/cases/components/view/InvestigationsSummaryTab.tsx
@@ -106,18 +106,18 @@ const InvestigationSummaryTab: React.FC<InvestigationSummaryTabProps> = ({
     }
   }, []);
 
-  const getAssigneeFullName = (assigneeName?: string, assignee?: string) => {
+  const getAssigneeFullName = (assignee?: string) => {
     const inv = investigators.find(
-      (i) => i.id === assigneeName || i.id === assignee,
+      (i) => i.id === assignee,
     );
     if (inv) return `${inv.firstName} ${inv.lastName}`;
 
     const sup = supervisors.find(
-      (i) => i.id === assigneeName || i.id === assignee,
+      (i) => i.id === assignee,
     );
     if (sup) return `${sup.firstName} ${sup.lastName}`;
 
-    return '';
+    return 'N/A';
   };
 
   const loadEvidence = React.useCallback(async (): Promise<void> => {
@@ -407,7 +407,7 @@ const InvestigationSummaryTab: React.FC<InvestigationSummaryTabProps> = ({
                   Investigator
                 </p>
                 <p className="text-sm font-semibold text-gray-900">
-                  {getAssigneeFullName(investigationTask.assigned_user_id) || 'N/A'}
+                  {getAssigneeFullName(investigationTask?.assigned_user_id)}
                 </p>
               </div>
               <div>

--- a/frontend/src/features/cases/components/view/InvestigationsSummaryTab.tsx
+++ b/frontend/src/features/cases/components/view/InvestigationsSummaryTab.tsx
@@ -10,7 +10,6 @@ import { caseService } from '../../services/caseService';
 import { evidenceService } from '../../services/evidenceService';
 import { commentService } from '../../services/commentService';
 import { taskService, TaskStatus } from '../../services/taskService';
-import userService from '../../services/userService';
 import type { Case } from '@/features/alerts/types/triage.types';
 import type { Evidence } from '../../types/evidence.types';
 import type { TaskComment } from '../../services/commentService';
@@ -19,6 +18,7 @@ import authService from '@/features/auth/services/authService';
 import type { UnifiedWorkQueueTask } from '../../types/task.types';
 import type { TaskForSupervisor } from '../../services/taskService';
 import { formatDate } from '@/shared/utils/dateUtils';
+import { useInvestigatorSupervisorList } from '../../hooks/useInvestigatorSupervisorList';
 
 const CompleteTaskModal = lazy(
   async () => await import('../modals/CompleteTaskModal'),
@@ -50,6 +50,12 @@ const InvestigationSummaryTab: React.FC<InvestigationSummaryTabProps> = ({
   refreshKey,
   task,
 }) => {
+  const {
+    investigators,
+    supervisors,
+    fetchInvestigatorsList,
+    fetchSupervisorsList,
+  } = useInvestigatorSupervisorList();
   const [currentTaskId, setCurrentTaskId] = useState<number | null>(null);
   const { success, error: toastError } = useToast();
   const [caseDetails, setCaseDetails] = useState<Case | null>(null);
@@ -59,7 +65,6 @@ const InvestigationSummaryTab: React.FC<InvestigationSummaryTabProps> = ({
   const [supervisorComments, setSupervisorComments] = useState<TaskComment[]>(
     [],
   );
-  const [investigatorName, setInvestigatorName] = useState<string>('N/A');
   const [loading, setLoading] = useState(true);
   const [expandedCategories, setExpandedCategories] = useState<Set<string>>(
     new Set(),
@@ -91,6 +96,29 @@ const InvestigationSummaryTab: React.FC<InvestigationSummaryTabProps> = ({
     dueDate: task.sla_deadline ?? undefined,
     caseId: task.case_id,
   });
+
+  useEffect(() => {
+    if (investigators.length === 0) {
+      fetchInvestigatorsList();
+    }
+    if (supervisors.length === 0) {
+      fetchSupervisorsList();
+    }
+  }, []);
+
+  const getAssigneeFullName = (assigneeName?: string, assignee?: string) => {
+    const inv = investigators.find(
+      (i) => i.id === assigneeName || i.id === assignee,
+    );
+    if (inv) return `${inv.firstName} ${inv.lastName}`;
+
+    const sup = supervisors.find(
+      (i) => i.id === assigneeName || i.id === assignee,
+    );
+    if (sup) return `${sup.firstName} ${sup.lastName}`;
+
+    return '';
+  };
 
   const loadEvidence = React.useCallback(async (): Promise<void> => {
     if (!currentTaskId) return;
@@ -281,17 +309,17 @@ const InvestigationSummaryTab: React.FC<InvestigationSummaryTabProps> = ({
           // Then find the approval task that comes after this investigation task
           const approvalTask = investigationTask
             ? tasks
-                .filter(
-                  (t) =>
-                    t.name?.toLowerCase().includes('approve') &&
-                    new Date(t.created_at || 0).getTime() >
-                      new Date(investigationTask.created_at || 0).getTime(),
-                )
-                .sort((a, b) => {
-                  const dateA = new Date(a.created_at || 0).getTime();
-                  const dateB = new Date(b.created_at || 0).getTime();
-                  return dateA - dateB; // ascending order (earliest approval after investigation)
-                })[0]
+              .filter(
+                (t) =>
+                  t.name?.toLowerCase().includes('approve') &&
+                  new Date(t.created_at || 0).getTime() >
+                  new Date(investigationTask.created_at || 0).getTime(),
+              )
+              .sort((a, b) => {
+                const dateA = new Date(a.created_at || 0).getTime();
+                const dateB = new Date(b.created_at || 0).getTime();
+                return dateA - dateB; // ascending order (earliest approval after investigation)
+              })[0]
             : undefined;
 
           if (approvalTask) {
@@ -319,14 +347,6 @@ const InvestigationSummaryTab: React.FC<InvestigationSummaryTabProps> = ({
                   ? formatDate(investigationTask.updated_at)
                   : 'N/A',
               );
-            }
-            if (investigationTask.assigned_user_id) {
-              const userDetails = await userService.getUserDetailsById(
-                investigationTask.assigned_user_id,
-              );
-              if (userDetails) {
-                setInvestigatorName(userService.formatUserName(userDetails));
-              }
             }
           }
         } catch (error) {
@@ -387,7 +407,7 @@ const InvestigationSummaryTab: React.FC<InvestigationSummaryTabProps> = ({
                   Investigator
                 </p>
                 <p className="text-sm font-semibold text-gray-900">
-                  {investigatorName}
+                  {getAssigneeFullName(investigationTask.assigned_user_id) || 'N/A'}
                 </p>
               </div>
               <div>
@@ -497,7 +517,7 @@ const InvestigationSummaryTab: React.FC<InvestigationSummaryTabProps> = ({
                       (caseDetails.status === 'STATUS_81_CLOSED_REFUTED' ||
                         caseDetails.status === 'STATUS_82_CLOSED_CONFIRMED' ||
                         caseDetails.status ===
-                          'STATUS_83_CLOSED_INCONCLUSIVE') && (
+                        'STATUS_83_CLOSED_INCONCLUSIVE') && (
                         <div className="p-3 bg-green-50 border border-green-200 rounded">
                           <p className="text-xs text-green-600 font-medium mb-1">
                             Supervisor Final Outcome

--- a/frontend/src/features/cases/components/view/TaskDetailsTab.tsx
+++ b/frontend/src/features/cases/components/view/TaskDetailsTab.tsx
@@ -38,35 +38,7 @@ const TaskDetailsTab: React.FC<TaskDetailsTabProps> = ({
   loadingTasks = false,
 }) => {
   const task = tasks.length > 0 ? tasks[0] : null;
-  const {
-    investigators,
-    supervisors,
-    fetchInvestigatorsList,
-    fetchSupervisorsList,
-  } = useInvestigatorSupervisorList();
-
-  useEffect(() => {
-    if (investigators.length === 0) {
-      fetchInvestigatorsList();
-    }
-    if (supervisors.length === 0) {
-      fetchSupervisorsList();
-    }
-  }, []);
-
-  const getAssigneeFullName = (assignee?: string) => {
-    const inv = investigators.find(
-      (i) => i.id === assignee,
-    );
-    if (inv) return `${inv.firstName} ${inv.lastName}`;
-
-    const sup = supervisors.find(
-      (i) => i.id === assignee,
-    );
-    if (sup) return `${sup.firstName} ${sup.lastName}`;
-
-    return 'Unassigned';
-  };
+  const { getAssigneeFullName } = useInvestigatorSupervisorList();
 
   const getTaskStatusColor = (status: string): string => {
     const statusConfig: Record<string, string> = {

--- a/frontend/src/features/cases/components/view/TaskDetailsTab.tsx
+++ b/frontend/src/features/cases/components/view/TaskDetailsTab.tsx
@@ -54,18 +54,18 @@ const TaskDetailsTab: React.FC<TaskDetailsTabProps> = ({
     }
   }, []);
 
-  const getAssigneeFullName = (assigneeName?: string, assignee?: string) => {
+  const getAssigneeFullName = (assignee?: string) => {
     const inv = investigators.find(
-      (i) => i.id === assigneeName || i.id === assignee,
+      (i) => i.id === assignee,
     );
     if (inv) return `${inv.firstName} ${inv.lastName}`;
 
     const sup = supervisors.find(
-      (i) => i.id === assigneeName || i.id === assignee,
+      (i) => i.id === assignee,
     );
     if (sup) return `${sup.firstName} ${sup.lastName}`;
 
-    return '';
+    return 'Unassigned';
   };
 
   const getTaskStatusColor = (status: string): string => {
@@ -211,11 +211,9 @@ const TaskDetailsTab: React.FC<TaskDetailsTabProps> = ({
                     Assigned To
                   </div>
                   <div className="font-medium text-gray-900">
-                    {task.assigned_user_id ? (
-                      getAssigneeFullName(task.assigned_user_id)
-                    ) : (
-                      'Unassigned'
-                    )}
+                    {task.assigned_user_id
+                      ? getAssigneeFullName(task.assigned_user_id)
+                      : 'Unassigned'}
                   </div>
                 </div>
               </div>

--- a/frontend/src/features/cases/components/view/TaskDetailsTab.tsx
+++ b/frontend/src/features/cases/components/view/TaskDetailsTab.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import type { CaseRow } from '../casesTable.utils';
 import type { TaskForSupervisor } from '../../services/taskService';
 import { formatDate } from '../../../../shared/utils/dateUtils';
-import userService, { type UserDetails } from '../../services/userService';
+import { useInvestigatorSupervisorList } from '../../hooks/useInvestigatorSupervisorList';
 
 interface TaskDetailsTabProps {
   row: CaseRow;
@@ -38,33 +38,35 @@ const TaskDetailsTab: React.FC<TaskDetailsTabProps> = ({
   loadingTasks = false,
 }) => {
   const task = tasks.length > 0 ? tasks[0] : null;
-  const [assignedUser, setAssignedUser] = React.useState<UserDetails | null>(
-    null,
-  );
-  const [loadingUser, setLoadingUser] = React.useState(false);
+  const {
+    investigators,
+    supervisors,
+    fetchInvestigatorsList,
+    fetchSupervisorsList,
+  } = useInvestigatorSupervisorList();
 
-  React.useEffect(() => {
-    const fetchUserDetails = async () => {
-      if (task?.assigned_user_id) {
-        setLoadingUser(true);
-        try {
-          const userDetails = await userService.getUserDetailsById(
-            task.assigned_user_id,
-          );
-          setAssignedUser(userDetails);
-        } catch (error) {
-          console.error('Failed to fetch user details:', error);
-          setAssignedUser(null);
-        } finally {
-          setLoadingUser(false);
-        }
-      } else {
-        setAssignedUser(null);
-      }
-    };
+  useEffect(() => {
+    if (investigators.length === 0) {
+      fetchInvestigatorsList();
+    }
+    if (supervisors.length === 0) {
+      fetchSupervisorsList();
+    }
+  }, []);
 
-    fetchUserDetails();
-  }, [task?.assigned_user_id]);
+  const getAssigneeFullName = (assigneeName?: string, assignee?: string) => {
+    const inv = investigators.find(
+      (i) => i.id === assigneeName || i.id === assignee,
+    );
+    if (inv) return `${inv.firstName} ${inv.lastName}`;
+
+    const sup = supervisors.find(
+      (i) => i.id === assigneeName || i.id === assignee,
+    );
+    if (sup) return `${sup.firstName} ${sup.lastName}`;
+
+    return '';
+  };
 
   const getTaskStatusColor = (status: string): string => {
     const statusConfig: Record<string, string> = {
@@ -209,18 +211,8 @@ const TaskDetailsTab: React.FC<TaskDetailsTabProps> = ({
                     Assigned To
                   </div>
                   <div className="font-medium text-gray-900">
-                    {loadingUser ? (
-                      <span className="text-gray-400">Loading...</span>
-                    ) : assignedUser ? (
-                      (() => {
-                        const fullName =
-                          `${assignedUser.firstName ?? ''} ${assignedUser.lastName ?? ''}`.trim();
-                        return fullName !== ''
-                          ? fullName
-                          : (assignedUser.username ?? 'Unknown');
-                      })()
-                    ) : task.assigned_user_id ? (
-                      task.assigned_user_id.substring(0, 8)
+                    {task.assigned_user_id ? (
+                      getAssigneeFullName(task.assigned_user_id)
                     ) : (
                       'Unassigned'
                     )}

--- a/frontend/src/features/cases/components/view/__tests__/InvestigationsSummaryTab.test.tsx
+++ b/frontend/src/features/cases/components/view/__tests__/InvestigationsSummaryTab.test.tsx
@@ -15,20 +15,11 @@ vi.mock('../../../services/taskService');
 vi.mock('@/features/auth/services/authService');
 vi.mock('../../../hooks/useInvestigatorSupervisorList', () => ({
   useInvestigatorSupervisorList: () => ({
-    investigators: [
-      {
-        id: 'user-1',
-        firstName: 'John',
-        lastName: 'Doe',
-      },
-    ],
-    supervisors: [
-      {
-        id: 'supervisor-1',
-        firstName: 'Jane',
-        lastName: 'Supervisor',
-      },
-    ],
+    getAssigneeFullName: (assignee?: string) => {
+      if (assignee === 'user-1') return 'John Doe';
+      if (assignee === 'supervisor-1') return 'Jane Supervisor';
+      return '';
+    },
     fetchInvestigatorsList: vi.fn(),
     fetchSupervisorsList: vi.fn(),
   }),

--- a/frontend/src/features/cases/components/view/__tests__/InvestigationsSummaryTab.test.tsx
+++ b/frontend/src/features/cases/components/view/__tests__/InvestigationsSummaryTab.test.tsx
@@ -6,15 +6,33 @@ import { caseService } from '../../../services/caseService';
 import { evidenceService } from '../../../services/evidenceService';
 import { commentService } from '../../../services/commentService';
 import { taskService } from '../../../services/taskService';
-import userService from '../../../services/userService';
 import authService from '@/features/auth/services/authService';
 
 vi.mock('../../../services/caseService');
 vi.mock('../../../services/evidenceService');
 vi.mock('../../../services/commentService');
 vi.mock('../../../services/taskService');
-vi.mock('../../../services/userService');
 vi.mock('@/features/auth/services/authService');
+vi.mock('../../../hooks/useInvestigatorSupervisorList', () => ({
+  useInvestigatorSupervisorList: () => ({
+    investigators: [
+      {
+        id: 'user-1',
+        firstName: 'John',
+        lastName: 'Doe',
+      },
+    ],
+    supervisors: [
+      {
+        id: 'supervisor-1',
+        firstName: 'Jane',
+        lastName: 'Supervisor',
+      },
+    ],
+    fetchInvestigatorsList: vi.fn(),
+    fetchSupervisorsList: vi.fn(),
+  }),
+}));
 const mockSuccess = vi.fn();
 const mockError = vi.fn();
 vi.mock('@/shared/providers/ToastProvider', () => ({
@@ -92,17 +110,11 @@ describe('InvestigationSummaryTab', () => {
     (evidenceService.formatFileSize as vi.Mock).mockReturnValue('1 KB');
     (taskService.getTasksByCaseId as vi.Mock).mockResolvedValue(mockTasks);
     (commentService.getCommentsByTask as vi.Mock).mockResolvedValue([]);
-    (userService.getUserDetailsById as vi.Mock).mockResolvedValue({
-      id: 'user-1',
-      firstName: 'John',
-      lastName: 'Doe',
-    });
-    (userService.formatUserName as vi.Mock).mockReturnValue('John Doe');
   });
 
   it('renders loading state initially', () => {
     (caseService.getCaseDetails as vi.Mock).mockImplementation(
-      () => new Promise(() => {}),
+      () => new Promise(() => { }),
     );
     render(<InvestigationSummaryTab caseId={123} task={mockTask} />);
     expect(document.querySelector('.animate-spin')).toBeInTheDocument();

--- a/frontend/src/features/cases/components/view/__tests__/TaskDetailsTab.test.tsx
+++ b/frontend/src/features/cases/components/view/__tests__/TaskDetailsTab.test.tsx
@@ -7,17 +7,14 @@ import type { TaskForSupervisor } from '../../../services/taskService';
 
 const mockFetchInvestigatorsList = vi.fn();
 const mockFetchSupervisorsList = vi.fn();
+const mockGetAssigneeFullName = vi.fn((assignee?: string) => {
+  if (assignee === 'user-1') return 'John Doe';
+  return '';
+});
 
 vi.mock('../../../hooks/useInvestigatorSupervisorList', () => ({
   useInvestigatorSupervisorList: () => ({
-    investigators: [
-      {
-        id: 'user-1',
-        firstName: 'John',
-        lastName: 'Doe',
-      },
-    ],
-    supervisors: [],
+    getAssigneeFullName: mockGetAssigneeFullName,
     fetchInvestigatorsList: mockFetchInvestigatorsList,
     fetchSupervisorsList: mockFetchSupervisorsList,
   }),

--- a/frontend/src/features/cases/components/view/__tests__/TaskDetailsTab.test.tsx
+++ b/frontend/src/features/cases/components/view/__tests__/TaskDetailsTab.test.tsx
@@ -4,9 +4,24 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import TaskDetailsTab from '../TaskDetailsTab';
 import type { CaseRow } from '../../casesTable.utils';
 import type { TaskForSupervisor } from '../../../services/taskService';
-import userService from '../../../services/userService';
 
-vi.mock('../../../services/userService');
+const mockFetchInvestigatorsList = vi.fn();
+const mockFetchSupervisorsList = vi.fn();
+
+vi.mock('../../../hooks/useInvestigatorSupervisorList', () => ({
+  useInvestigatorSupervisorList: () => ({
+    investigators: [
+      {
+        id: 'user-1',
+        firstName: 'John',
+        lastName: 'Doe',
+      },
+    ],
+    supervisors: [],
+    fetchInvestigatorsList: mockFetchInvestigatorsList,
+    fetchSupervisorsList: mockFetchSupervisorsList,
+  }),
+}));
 
 const mockCaseRow: CaseRow = {
   id: 123,
@@ -46,12 +61,6 @@ const mockTask: TaskForSupervisor = {
 describe('TaskDetailsTab', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    (userService.getUserDetailsById as vi.Mock).mockResolvedValue({
-      id: 'user-1',
-      firstName: 'John',
-      lastName: 'Doe',
-      username: 'jdoe',
-    });
   });
 
   it('renders loading state when loadingTasks is true', () => {
@@ -75,11 +84,11 @@ describe('TaskDetailsTab', () => {
     });
   });
 
-  it('fetches user details when task has assigned_user_id', async () => {
+  it('renders assignee full name when task has assigned_user_id', async () => {
     render(<TaskDetailsTab row={mockCaseRow} tasks={[mockTask]} />);
 
     await waitFor(() => {
-      expect(userService.getUserDetailsById).toHaveBeenCalledWith('user-1');
+      expect(screen.getByText('John Doe')).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/features/cases/hooks/useInvestigatorSupervisorList.ts
+++ b/frontend/src/features/cases/hooks/useInvestigatorSupervisorList.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import userService from '../services/userService';
 import type { UserOption } from '../services/userService';
 
@@ -11,6 +11,7 @@ export const useInvestigatorSupervisorList = (): {
   fetchInvestigatorsList: () => Promise<void>;
   fetchSupervisorsList: () => Promise<void>;
   fetchComplianceOfficersList: () => Promise<void>;
+  getAssigneeFullName: (assignee?: string) => string;
   clearCache: () => void;
 } => {
   const supervisorsCacheKey = 'supervisors';
@@ -109,6 +110,31 @@ export const useInvestigatorSupervisorList = (): {
     }
   };
 
+  const getAssigneeFullName = useCallback(
+    (assignee?: string): string => {
+      const compliance = complianceOfficers.find((i) => i.id === assignee);
+
+      if (compliance) {
+        return `${compliance.firstName} ${compliance.lastName}`;
+      }
+
+      const investigator = investigators.find((i) => i.id === assignee);
+
+      if (investigator) {
+        return `${investigator.firstName} ${investigator.lastName}`;
+      }
+
+      const supervisor = supervisors.find((i) => i.id === assignee);
+
+      if (supervisor) {
+        return `${supervisor.firstName} ${supervisor.lastName}`;
+      }
+
+      return '';
+    },
+    [complianceOfficers, investigators, supervisors],
+  );
+
   const clearCache = (): void => {
     sessionStorage.removeItem(investigatorsCacheKey);
     setInvestigators([]);
@@ -131,6 +157,7 @@ export const useInvestigatorSupervisorList = (): {
     fetchInvestigatorsList,
     fetchSupervisorsList,
     fetchComplianceOfficersList,
+    getAssigneeFullName,
     clearCache,
   };
 };

--- a/frontend/src/features/cases/utils/__tests__/investigationUtils.test.ts
+++ b/frontend/src/features/cases/utils/__tests__/investigationUtils.test.ts
@@ -4,7 +4,6 @@ import { evidenceService } from '../../services/evidenceService';
 import { caseService } from '../../services/caseService';
 import { commentService } from '../../services/commentService';
 import { taskService } from '../../services/taskService';
-import userService from '../../services/userService';
 
 vi.mock('../../services/evidenceService', () => ({
   evidenceService: { getTaskEvidence: vi.fn() },
@@ -17,9 +16,6 @@ vi.mock('../../services/commentService', () => ({
 }));
 vi.mock('../../services/taskService', () => ({
   taskService: { getTasksByCaseId: vi.fn() },
-}));
-vi.mock('../../services/userService', () => ({
-  default: { getUserDetailsById: vi.fn(), formatUserName: vi.fn() },
 }));
 
 const mockGetEv = vi.mocked(evidenceService.getTaskEvidence);
@@ -154,7 +150,7 @@ describe('fetchCasesAndEvidence', () => {
     expect(result.investigationTask).toBeUndefined();
   });
 
-  it('populates investigator name from user details', async () => {
+  it('keeps default investigator name when task has assignee', async () => {
     (caseService.getCaseDetails as vi.Mock).mockResolvedValue({ case_id: 1 });
     (taskService.getTasksByCaseId as vi.Mock).mockResolvedValue([
       {
@@ -164,15 +160,10 @@ describe('fetchCasesAndEvidence', () => {
         investigationNotes: 'Some notes',
       },
     ]);
-    (userService.getUserDetailsById as vi.Mock).mockResolvedValue({
-      firstName: 'John',
-      lastName: 'Doe',
-    });
-    (userService.formatUserName as vi.Mock).mockReturnValue('John Doe');
 
     const result = await fetchCasesAndEvidence(1, 10);
 
-    expect(result.investigatorName).toBe('John Doe');
+    expect(result.investigatorName).toBe('N/A');
     expect(result.investigationNotes).toBe('Some notes');
   });
 
@@ -211,7 +202,6 @@ describe('fetchCasesAndEvidence', () => {
     (taskService.getTasksByCaseId as vi.Mock).mockResolvedValue([
       { task_id: 10, assigned_user_id: 'user-1' },
     ]);
-    (userService.getUserDetailsById as vi.Mock).mockResolvedValue(null);
 
     const result = await fetchCasesAndEvidence(1, 10);
     expect(result.investigatorName).toBe('N/A');

--- a/frontend/src/features/cases/utils/investigationUtils.tsx
+++ b/frontend/src/features/cases/utils/investigationUtils.tsx
@@ -5,7 +5,6 @@ import { evidenceService } from '../services/evidenceService';
 import { caseService } from '../services/caseService';
 import { commentService } from '../services/commentService';
 import { taskService } from '../services/taskService';
-import userService from '../services/userService';
 import { formatDate } from '@/shared/utils/dateUtils';
 
 export interface EvidenceCategory {
@@ -116,14 +115,6 @@ export const fetchCasesAndEvidence = async (
         investigationNotes = investigationTask.investigationNotes;
       }
 
-      if (investigationTask.assigned_user_id) {
-        const userDetails = await userService.getUserDetailsById(
-          investigationTask.assigned_user_id,
-        );
-        if (userDetails) {
-          investigatorName = userService.formatUserName(userDetails);
-        }
-      }
     }
 
     const approvalTask = tasks.find((t) =>

--- a/frontend/src/features/reports/components/CaseAgeingTable.tsx
+++ b/frontend/src/features/reports/components/CaseAgeingTable.tsx
@@ -32,13 +32,13 @@ const CaseAgeingTable: React.FC<CaseAgeingTableProps> = ({
   const { currentPage, totalPages, paginatedData, setCurrentPage } =
     usePagination({
       data,
-      defaultItemsPerPage: 10,
+      defaultItemsPerPage: 5,
     });
 
   // Create pagination object for TablePagination
   const pagination: TablePaginationInfo = {
     currentPage,
-    pageSize: 10, // Fixed page size since usePagination doesn't expose itemsPerPage in a way we need
+    pageSize: 5, // Fixed page size since usePagination doesn't expose itemsPerPage in a way we need
     totalItems: data.length,
     totalPages,
     onPageChange: setCurrentPage,

--- a/frontend/src/features/reports/components/CaseAgeingTable.tsx
+++ b/frontend/src/features/reports/components/CaseAgeingTable.tsx
@@ -20,14 +20,7 @@ const CaseAgeingTable: React.FC<CaseAgeingTableProps> = ({
   onExportCSV,
   onExportPDF,
 }) => {
-  const {
-    investigators,
-    supervisors,
-    fetchInvestigatorsList,
-    fetchSupervisorsList,
-    complianceOfficers,
-    fetchComplianceOfficersList,
-  } = useInvestigatorSupervisorList();
+  const { getAssigneeFullName } = useInvestigatorSupervisorList();
 
   const { currentPage, totalPages, paginatedData, setCurrentPage } =
     usePagination({
@@ -62,37 +55,6 @@ const CaseAgeingTable: React.FC<CaseAgeingTableProps> = ({
       default:
         return 'text-gray-600';
     }
-  };
-
-  useEffect(() => {
-    if (investigators.length === 0) {
-      fetchInvestigatorsList();
-    }
-    if (supervisors.length === 0) {
-      fetchSupervisorsList();
-    }
-    if (complianceOfficers.length === 0) {
-      fetchComplianceOfficersList();
-    }
-  }, []);
-
-  const getAssigneeFullName = (assigneeName?: string, assignee?: string) => {
-    const compliance = complianceOfficers.find(
-      (i) => i.id === assigneeName || i.id === assignee,
-    );
-    if (compliance) return `${compliance.firstName} ${compliance.lastName}`;
-
-    const inv = investigators.find(
-      (i) => i.id === assigneeName || i.id === assignee,
-    );
-    if (inv) return `${inv.firstName} ${inv.lastName}`;
-
-    const sup = supervisors.find(
-      (i) => i.id === assigneeName || i.id === assignee,
-    );
-    if (sup) return `${sup.firstName} ${sup.lastName}`;
-
-    return '';
   };
 
   return (

--- a/frontend/src/features/reports/components/CaseAgeingTable.tsx
+++ b/frontend/src/features/reports/components/CaseAgeingTable.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import type { CaseAgeingDetail } from '../types/reports.types';
 import { usePagination } from '../../../shared/hooks/usePagination';
 import TablePagination from '../../../shared/components/TablePagination';
 import type { TablePaginationInfo } from '../../../shared/types/pagination.types';
+import { useInvestigatorSupervisorList } from '@/features/cases/hooks/useInvestigatorSupervisorList';
 
 interface CaseAgeingTableProps {
   data: CaseAgeingDetail[];
@@ -19,6 +20,15 @@ const CaseAgeingTable: React.FC<CaseAgeingTableProps> = ({
   onExportCSV,
   onExportPDF,
 }) => {
+  const {
+    investigators,
+    supervisors,
+    fetchInvestigatorsList,
+    fetchSupervisorsList,
+    complianceOfficers,
+    fetchComplianceOfficersList,
+  } = useInvestigatorSupervisorList();
+
   const { currentPage, totalPages, paginatedData, setCurrentPage } =
     usePagination({
       data,
@@ -52,6 +62,37 @@ const CaseAgeingTable: React.FC<CaseAgeingTableProps> = ({
       default:
         return 'text-gray-600';
     }
+  };
+
+  useEffect(() => {
+    if (investigators.length === 0) {
+      fetchInvestigatorsList();
+    }
+    if (supervisors.length === 0) {
+      fetchSupervisorsList();
+    }
+    if (complianceOfficers.length === 0) {
+      fetchComplianceOfficersList();
+    }
+  }, []);
+
+  const getAssigneeFullName = (assigneeName?: string, assignee?: string) => {
+    const compliance = complianceOfficers.find(
+      (i) => i.id === assigneeName || i.id === assignee,
+    );
+    if (compliance) return `${compliance.firstName} ${compliance.lastName}`;
+
+    const inv = investigators.find(
+      (i) => i.id === assigneeName || i.id === assignee,
+    );
+    if (inv) return `${inv.firstName} ${inv.lastName}`;
+
+    const sup = supervisors.find(
+      (i) => i.id === assigneeName || i.id === assignee,
+    );
+    if (sup) return `${sup.firstName} ${sup.lastName}`;
+
+    return '';
   };
 
   return (
@@ -180,7 +221,7 @@ const CaseAgeingTable: React.FC<CaseAgeingTableProps> = ({
                   </td>
                   <td className="px-4 py-3 text-sm text-gray-900">
                     <div className="break-words">
-                      {row.investigator || 'Unassigned'}
+                      {getAssigneeFullName(row.investigator) || 'Unassigned'}
                     </div>
                   </td>
                 </tr>

--- a/frontend/src/features/reports/components/__tests__/CaseAgeingTable.test.tsx
+++ b/frontend/src/features/reports/components/__tests__/CaseAgeingTable.test.tsx
@@ -7,12 +7,11 @@ import type { CaseAgeingDetail } from '../../types/reports.types';
 
 vi.mock('@/features/cases/hooks/useInvestigatorSupervisorList', () => ({
   useInvestigatorSupervisorList: () => ({
-    investigators: [
-      { id: 'user-1', firstName: 'John', lastName: 'Doe' },
-      { id: 'user-2', firstName: 'Jane', lastName: 'Smith' },
-    ],
-    supervisors: [],
-    complianceOfficers: [],
+    getAssigneeFullName: (assignee?: string) => {
+      if (assignee === 'user-1') return 'John Doe';
+      if (assignee === 'user-2') return 'Jane Smith';
+      return '';
+    },
     fetchInvestigatorsList: vi.fn(),
     fetchSupervisorsList: vi.fn(),
     fetchComplianceOfficersList: vi.fn(),

--- a/frontend/src/features/reports/components/__tests__/CaseAgeingTable.test.tsx
+++ b/frontend/src/features/reports/components/__tests__/CaseAgeingTable.test.tsx
@@ -5,6 +5,20 @@ import userEvent from '@testing-library/user-event';
 import CaseAgeingTable from '../CaseAgeingTable';
 import type { CaseAgeingDetail } from '../../types/reports.types';
 
+vi.mock('@/features/cases/hooks/useInvestigatorSupervisorList', () => ({
+  useInvestigatorSupervisorList: () => ({
+    investigators: [
+      { id: 'user-1', firstName: 'John', lastName: 'Doe' },
+      { id: 'user-2', firstName: 'Jane', lastName: 'Smith' },
+    ],
+    supervisors: [],
+    complianceOfficers: [],
+    fetchInvestigatorsList: vi.fn(),
+    fetchSupervisorsList: vi.fn(),
+    fetchComplianceOfficersList: vi.fn(),
+  }),
+}));
+
 // Mock authService (not used by component but may be needed by imports)
 vi.mock('@/features/auth/services/authService', () => ({
   default: {
@@ -87,7 +101,7 @@ describe('CaseAgeingTable', () => {
       createdDate: '2024-01-01',
       ageDays: 5,
       priority: 'High',
-      investigator: 'User user-1',
+      investigator: 'user-1',
     },
     {
       caseId: 'CASE-2',
@@ -96,7 +110,7 @@ describe('CaseAgeingTable', () => {
       createdDate: '2024-01-05',
       ageDays: 12,
       priority: 'Medium',
-      investigator: 'User user-2',
+      investigator: 'user-2',
     },
     {
       caseId: 'CASE-3',
@@ -171,8 +185,8 @@ describe('CaseAgeingTable', () => {
     render(<CaseAgeingTable data={mockData} title="Case Ageing" />);
 
     await waitFor(() => {
-      expect(screen.getByText('User user-1')).toBeInTheDocument();
-      expect(screen.getByText('User user-2')).toBeInTheDocument();
+      expect(screen.getByText('John Doe')).toBeInTheDocument();
+      expect(screen.getByText('Jane Smith')).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
- Fixed the task details view to correctly display the assigned investigator information.
- Updated data mapping and rendering logic to ensure investigator details are shown when available.

## Why are we doing this?
- Users need to see the assigned investigator when reviewing task details.
- Missing investigator information caused confusion and reduced visibility into task ownership and assignment status.

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Investigator/supervisor names now resolve from a shared helper and display consistently across reports, task details, case views, and generated reports.

* **Bug Fixes**
  * Activity logs and task history show assignee full names for clearer audit messages.
  * UI falls back to “N/A” or “Unassigned” when no investigator name is available.
  * Case Ageing now shows the full set of cases (not limited).

* **Style**
  * Pagination defaults updated to 5 items per page.

* **Tests**
  * Tests updated to reflect the new investigator/supervisor data source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->