### PR TITLE
fix: fixed the visualization alert navigator tab

### DIFF
--- a/backend/src/modules/event_log/eventLog.service.ts
+++ b/backend/src/modules/event_log/eventLog.service.ts
@@ -20,7 +20,6 @@ export class EventLogService {
       throw new Error('Missing tenantId in event log write');
     }
     const userId = data.userId && isUuid(data.userId) ? data.userId : uuidv4();
-    const { tenantId } = data;
     return await this.prisma.eventLog.create({
       data: {
         user_id: userId,

--- a/backend/src/modules/gold-lakehouse/alerts-lakehouse.service.ts
+++ b/backend/src/modules/gold-lakehouse/alerts-lakehouse.service.ts
@@ -180,6 +180,7 @@ export class AlertsLakehouseService extends GoldLakehouseService {
               ruleId: r.rule_id,
               ruleWeight: r.rule_weight,
               subRef: r.rule_sub_ref,
+              independentVariable: r.rule_independent_variable,
             })),
           );
 

--- a/backend/src/modules/triage/triage.service.ts
+++ b/backend/src/modules/triage/triage.service.ts
@@ -48,7 +48,7 @@ export class TriageService {
     private readonly caseCreateService: CaseCreationService,
     private readonly loggingOrchestrationService: LoggingOrchestrationService,
     private readonly prisma: PrismaService,
-  ) { }
+  ) {}
 
   async getAlertNavigator(alertId: number, tenantId: string, userId: string): Promise<AlertNavigatorDto> {
     this.logger.log(`Fetching alert navigator for alertId: ${alertId}, tenantId: ${tenantId}, userId: ${userId}`, TriageService.name);

--- a/frontend/src/features/cases/components/view/visualizations/alertnavigator/AlertNavigatorTab.tsx
+++ b/frontend/src/features/cases/components/view/visualizations/alertnavigator/AlertNavigatorTab.tsx
@@ -235,18 +235,29 @@ const AlertNavigatorTab: React.FC<AlertNavigatorTabProps> = ({
                     ) : (
                       <ChevronDownIcon className="h-4 w-4 text-gray-500" />
                     )}
-                    <div className="flex items-center gap-2">
+                    <div className="flex items-center gap-3 flex-wrap">
                       <div
-                        className={`h-2 w-2 rounded-full ${
-                          typology.typologyScore >= 80
-                            ? 'bg-red-500'
-                            : typology.typologyScore >= 60
-                              ? 'bg-orange-500'
-                              : 'bg-yellow-500'
-                        }`}
+                        className={`h-2 w-2 rounded-full ${typology.typologyScore >= 80
+                          ? 'bg-red-500'
+                          : typology.typologyScore >= 60
+                            ? 'bg-orange-500'
+                            : 'bg-yellow-500'
+                          }`}
                       />
+
+                      {/* CFG */}
                       <span className="text-sm font-medium text-gray-900">
-                        {typology.typologyId}
+                        {typology.typologyCfg}
+                      </span>
+
+                      {/* Alert Threshold */}
+                      <span className="text-xs font-medium text-blue-700 bg-blue-100 px-2 py-0.5 rounded">
+                        Alert Threshold: {typology.alertThreshold}
+                      </span>
+
+                      {/* Interdiction Threshold */}
+                      <span className="text-xs font-medium text-orange-700 bg-orange-100 px-2 py-0.5 rounded">
+                        Interdiction Threshold: {typology.interdictionThreshold}
                       </span>
                     </div>
                   </div>
@@ -256,7 +267,7 @@ const AlertNavigatorTab: React.FC<AlertNavigatorTabProps> = ({
                         typology.typologyScore,
                       )}`}
                     >
-                      Score: {typology.typologyScore.toFixed(2)}
+                      Typology Score: {typology.typologyScore.toFixed(2)}
                     </span>
                     <div className="w-24 bg-gray-200 rounded-full h-2">
                       <div
@@ -286,6 +297,11 @@ const AlertNavigatorTab: React.FC<AlertNavigatorTabProps> = ({
                             {rule.subRef && (
                               <div className="text-xs text-gray-500 mt-0.5">
                                 Sub-ref: {rule.subRef}
+                              </div>
+                            )}
+                            {rule.independentVariable && (
+                              <div className="text-xs text-gray-500 mt-0.5">
+                                Independent Variable: {rule.independentVariable}
                               </div>
                             )}
                           </div>
@@ -335,11 +351,11 @@ const AlertNavigatorTab: React.FC<AlertNavigatorTabProps> = ({
             <span className="text-2xl font-bold text-gray-900">
               {data.typologies && data.typologies.length > 0
                 ? (
-                    data.typologies.reduce(
-                      (sum: number, t) => sum + t.typologyScore,
-                      0,
-                    ) / data.typologies.length
-                  ).toFixed(0)
+                  data.typologies.reduce(
+                    (sum: number, t) => sum + t.typologyScore,
+                    0,
+                  ) / data.typologies.length
+                ).toFixed(0)
                 : '0'}
             </span>
           </div>

--- a/frontend/src/features/cases/components/view/visualizations/alertnavigator/types/index.ts
+++ b/frontend/src/features/cases/components/view/visualizations/alertnavigator/types/index.ts
@@ -2,6 +2,7 @@ export interface RuleDetailDto {
   ruleId: string;
   ruleWeight: number;
   subRef?: string;
+  independentVariable?: string;
 }
 
 export interface TypologyDto {


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?

Typology name is now displayed as typologyResult.typology_cfg instead of typologyResult.id
The "score" is renamed to "typology score"
Alert threshold and interadiction threshold is now being displayed for each typology
Independent variable is now being displayed for each rule
Typology score is now being displayed using typology_score field fetched from Lakehouse,

## Why are we doing this?

To make the typology output clearer, more meaningful, and aligned with the data source.

Use readable typology names instead of IDs for better understanding
Rename “score” to “typology score” for clarity
Show alert and interdiction thresholds for better decision context
Display independent variables to improve transparency per rule
Use typology_score from Lakehouse for consistent and reliable scoring

## How was it tested?
- [x] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced alert navigator to display CFG badges and alert/interdiction thresholds in typology rows.
  * Added independent variable details visible when expanding typologies.

* **Bug Fixes**
  * Improved validation with explicit error messaging for missing tenant identifiers.

* **Style**
  * Code formatting adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->