### PR TITLE
fix: Hide Visualization for non Pacs002

### DIFF
--- a/frontend/src/features/cases/components/TasksDetailsModal.tsx
+++ b/frontend/src/features/cases/components/TasksDetailsModal.tsx
@@ -100,7 +100,7 @@ const TaskDetailsModal: React.FC<TaskDetailsModalProps> = ({
     if (open && initialCaseIdRef.current && row?.id !== initialCaseIdRef.current) {
       onClose();
     }
-    
+
     if (open) {
       initialCaseIdRef.current = row?.id;
     }
@@ -148,12 +148,67 @@ const TaskDetailsModal: React.FC<TaskDetailsModalProps> = ({
     return undefined;
   }, [row, parentCaseDetails]);
 
+  const shouldShowVisualizations = React.useMemo(() => {
+    const alertTxtp = row?.parentId
+      ? parentCaseDetails?.alert?.txtp
+      : undefined;
+
+    if (
+      typeof alertTxtp === 'string' &&
+      alertTxtp.toLowerCase().includes('pacs.002')
+    ) {
+      return true;
+    }
+
+    let transactionData = row?.parentId
+      ? parentCaseDetails?.alert.transaction
+      : row?.transaction;
+
+    if (!transactionData) {
+      return true;
+    }
+
+    if (typeof transactionData === 'string') {
+      try {
+        transactionData = JSON.parse(transactionData);
+      } catch {
+        return true;
+      }
+    }
+
+    if (typeof transactionData !== 'object' || transactionData === null) {
+      return true;
+    }
+
+    const transactionRecord = transactionData as Record<string, unknown>;
+
+    if (typeof transactionRecord.tx_type === 'string') {
+      return transactionRecord.tx_type.toLowerCase().includes('pacs.002');
+    }
+
+    if (typeof transactionRecord.txTp === 'string') {
+      return transactionRecord.txTp.toLowerCase().includes('pacs.002');
+    }
+
+    if ('FIToFIPmtSts' in transactionRecord) {
+      return true;
+    }
+
+    return true;
+  }, [row?.parentId, row?.transaction, parentCaseDetails]);
+
+  React.useEffect(() => {
+    if (!shouldShowVisualizations && tab === 'visualizations') {
+      setTab('details');
+    }
+  }, [shouldShowVisualizations, tab]);
+
   if (!open || !row) return null;
 
   return (
     <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/30 p-4">
       <div className="mt-6 w-full max-w-5xl rounded-lg bg-white shadow-lg max-h-[85vh] flex flex-col">
-        {}
+        { }
         <div className="flex items-center justify-between px-6 py-4">
           <div className="flex items-center gap-3">
             <h3 className="text-lg font-semibold text-gray-900">
@@ -169,7 +224,7 @@ const TaskDetailsModal: React.FC<TaskDetailsModalProps> = ({
           </button>
         </div>
 
-        {}
+        { }
         {!showCollaborate && (
           <div className="flex items-center gap-2 px-6 pt-3">
             {(
@@ -177,7 +232,14 @@ const TaskDetailsModal: React.FC<TaskDetailsModalProps> = ({
                 { key: 'details', label: 'Task Details' },
                 { key: 'linked', label: 'Linked Items' },
                 { key: 'evidence', label: 'Evidence' },
-                { key: 'visualizations', label: 'Visualizations' },
+                ...(shouldShowVisualizations
+                  ? ([
+                    {
+                      key: 'visualizations',
+                      label: 'Visualizations',
+                    },
+                  ] as const)
+                  : []),
                 { key: 'notes', label: 'Investigation Notes' },
                 { key: 'summary', label: 'Investigation Summary' },
               ] satisfies Array<{ key: ViewTabKey; label: string }>
@@ -187,11 +249,10 @@ const TaskDetailsModal: React.FC<TaskDetailsModalProps> = ({
                 onClick={() => {
                   setTab(t.key);
                 }}
-                className={`-mb-px rounded-t-md px-3 py-2 text-sm font-medium ${
-                  tab === t.key
-                    ? 'border-b-2 border-indigo-600 text-indigo-700'
-                    : 'text-gray-600 hover:text-gray-800'
-                }`}
+                className={`-mb-px rounded-t-md px-3 py-2 text-sm font-medium ${tab === t.key
+                  ? 'border-b-2 border-indigo-600 text-indigo-700'
+                  : 'text-gray-600 hover:text-gray-800'
+                  }`}
               >
                 {t.label}
               </button>
@@ -199,7 +260,7 @@ const TaskDetailsModal: React.FC<TaskDetailsModalProps> = ({
           </div>
         )}
 
-        {}
+        { }
         {/* Content */}
         <div className="px-6 py-5 overflow-y-auto flex-1">
           {showCollaborate ? (
@@ -225,15 +286,17 @@ const TaskDetailsModal: React.FC<TaskDetailsModalProps> = ({
                   }}
                 />
               </div>
-              <div
-                style={{ display: tab === 'visualizations' ? 'block' : 'none' }}
-              >
-                <VisualizationsTab
-                  alertId={row?.parentId ? parentAlertId : row?.alertId}
-                  caseId={row?.id}
-                  transactionId={transactionId}
-                />
-              </div>
+              {shouldShowVisualizations && (
+                <div
+                  style={{ display: tab === 'visualizations' ? 'block' : 'none' }}
+                >
+                  <VisualizationsTab
+                    alertId={row?.parentId ? parentAlertId : row?.alertId}
+                    caseId={row?.id}
+                    transactionId={transactionId}
+                  />
+                </div>
+              )}
               <div style={{ display: tab === 'linked' ? 'block' : 'none' }}>
                 {row?.id && (
                   <LinkedItemsTab
@@ -282,7 +345,7 @@ const TaskDetailsModal: React.FC<TaskDetailsModalProps> = ({
           )}
         </div>
 
-        {}
+        { }
         <div className="flex items-center justify-end gap-3 border-t border-gray-200 px-6 py-4">
           <button
             type="button"

--- a/frontend/src/features/cases/components/TasksDetailsModal.tsx
+++ b/frontend/src/features/cases/components/TasksDetailsModal.tsx
@@ -51,12 +51,16 @@ const TaskDetailsModal: React.FC<TaskDetailsModalProps> = ({
   const [parentCaseDetails, setParentCaseDetails] = React.useState<
     Case | undefined
   >(undefined);
+  const [isParentCaseLoading, setIsParentCaseLoading] =
+    React.useState(false);
+  const [shouldShowVisualizations, setShouldShowVisualizations] = React.useState(false);
 
   const [summaryRefreshKey, setSummaryRefreshKey] = React.useState(0);
   const initialCaseIdRef = React.useRef<number | undefined>(undefined);
 
   React.useEffect(() => {
     if (row?.parentId) {
+      setIsParentCaseLoading(true);
       caseService
         .getCaseDetails(row.parentId)
         .then((details) => {
@@ -66,7 +70,15 @@ const TaskDetailsModal: React.FC<TaskDetailsModalProps> = ({
         .catch((error) => {
           console.error('Failed to fetch case details for parent case:', error);
           setParentAlertId(undefined);
+          setParentCaseDetails(undefined);
+        })
+        .finally(() => {
+          setIsParentCaseLoading(false);
         });
+    } else {
+      setParentAlertId(undefined);
+      setParentCaseDetails(undefined);
+      setIsParentCaseLoading(false);
     }
   }, [row?.parentId]);
 
@@ -108,6 +120,11 @@ const TaskDetailsModal: React.FC<TaskDetailsModalProps> = ({
 
   //Extract transaction ID from transaction data
   const transactionId = React.useMemo(() => {
+    if (row?.parentId && isParentCaseLoading) {
+      // Wait for parent details before deciding visibility to avoid tab flicker.
+      return undefined;
+    }
+
     let transactionData = row?.parentId
       ? parentCaseDetails?.alert.transaction
       : row?.transaction;
@@ -126,6 +143,7 @@ const TaskDetailsModal: React.FC<TaskDetailsModalProps> = ({
     }
 
     const transaction = transactionData as Record<string, unknown>;
+    setShouldShowVisualizations(transaction?.FIToFIPmtSts !== undefined);
 
     const fiToFIPmtSts = transaction?.FIToFIPmtSts as
       | Record<string, unknown>
@@ -148,57 +166,8 @@ const TaskDetailsModal: React.FC<TaskDetailsModalProps> = ({
     return undefined;
   }, [row, parentCaseDetails]);
 
-  const shouldShowVisualizations = React.useMemo(() => {
-    const alertTxtp = row?.parentId
-      ? parentCaseDetails?.alert?.txtp
-      : undefined;
-
-    if (
-      typeof alertTxtp === 'string' &&
-      alertTxtp.toLowerCase().includes('pacs.002')
-    ) {
-      return true;
-    }
-
-    let transactionData = row?.parentId
-      ? parentCaseDetails?.alert.transaction
-      : row?.transaction;
-
-    if (!transactionData) {
-      return true;
-    }
-
-    if (typeof transactionData === 'string') {
-      try {
-        transactionData = JSON.parse(transactionData);
-      } catch {
-        return true;
-      }
-    }
-
-    if (typeof transactionData !== 'object' || transactionData === null) {
-      return true;
-    }
-
-    const transactionRecord = transactionData as Record<string, unknown>;
-
-    if (typeof transactionRecord.tx_type === 'string') {
-      return transactionRecord.tx_type.toLowerCase().includes('pacs.002');
-    }
-
-    if (typeof transactionRecord.txTp === 'string') {
-      return transactionRecord.txTp.toLowerCase().includes('pacs.002');
-    }
-
-    if ('FIToFIPmtSts' in transactionRecord) {
-      return true;
-    }
-
-    return true;
-  }, [row?.parentId, row?.transaction, parentCaseDetails]);
-
   React.useEffect(() => {
-    if (!shouldShowVisualizations && tab === 'visualizations') {
+    if (shouldShowVisualizations === false && tab === 'visualizations') {
       setTab('details');
     }
   }, [shouldShowVisualizations, tab]);
@@ -232,7 +201,7 @@ const TaskDetailsModal: React.FC<TaskDetailsModalProps> = ({
                 { key: 'details', label: 'Task Details' },
                 { key: 'linked', label: 'Linked Items' },
                 { key: 'evidence', label: 'Evidence' },
-                ...(shouldShowVisualizations
+                ...(shouldShowVisualizations === true
                   ? ([
                     {
                       key: 'visualizations',
@@ -286,7 +255,7 @@ const TaskDetailsModal: React.FC<TaskDetailsModalProps> = ({
                   }}
                 />
               </div>
-              {shouldShowVisualizations && (
+              {shouldShowVisualizations === true && (
                 <div
                   style={{ display: tab === 'visualizations' ? 'block' : 'none' }}
                 >

--- a/frontend/src/features/cases/components/__tests__/TasksDetailsModal.test.tsx
+++ b/frontend/src/features/cases/components/__tests__/TasksDetailsModal.test.tsx
@@ -213,7 +213,7 @@ describe('TasksDetailsModal', () => {
     const caseWithNonPacs002: CaseRow = {
       ...mockCaseData,
       transaction: JSON.stringify({
-        tx_type: 'pacs.008.001.10',
+        TxTp: 'pacs.008.001.10',
       }),
     };
 
@@ -274,6 +274,37 @@ describe('TasksDetailsModal', () => {
 
     await waitFor(() => {
       expect(mockGetCaseDetails).toHaveBeenCalledWith(999);
+    });
+  });
+
+  it('defers Visualizations tab visibility until parent case details finish loading', async () => {
+    let resolveParentCase: ((value: unknown) => void) | undefined;
+    mockGetCaseDetails.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveParentCase = resolve;
+        }),
+    );
+
+    renderModal({ row: mockCaseWithParent });
+
+    expect(screen.queryByText('Visualizations')).not.toBeInTheDocument();
+
+    resolveParentCase?.({
+      alert: {
+        alert_id: 42,
+        transaction: JSON.stringify({
+          FIToFIPmtSts: {
+            TxInfAndSts: {
+              OrgnlEndToEndId: 'PARENT-TXN-001',
+            },
+          },
+        }),
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Visualizations')).toBeInTheDocument();
     });
   });
 
@@ -342,28 +373,24 @@ describe('TasksDetailsModal', () => {
     });
   });
 
-  it('returns undefined transactionId when transaction data is invalid JSON', async () => {
-    const user = userEvent.setup();
+  it('hides Visualizations when transaction data is invalid JSON', () => {
     const caseWithBadTransaction: CaseRow = {
       ...mockCaseData,
       transaction: 'invalid json{{{',
     };
     renderModal({ row: caseWithBadTransaction });
 
-    await user.click(screen.getByText('Visualizations'));
-    expect(screen.queryByText(/txn:/)).not.toBeInTheDocument();
+    expect(screen.queryByText('Visualizations')).not.toBeInTheDocument();
   });
 
-  it('returns undefined transactionId when transaction is null', async () => {
-    const user = userEvent.setup();
+  it('hides Visualizations when transaction is null', () => {
     const caseWithNoTransaction: CaseRow = {
       ...mockCaseData,
       transaction: undefined,
     };
     renderModal({ row: caseWithNoTransaction });
 
-    await user.click(screen.getByText('Visualizations'));
-    expect(screen.queryByText(/txn:/)).not.toBeInTheDocument();
+    expect(screen.queryByText('Visualizations')).not.toBeInTheDocument();
   });
 
   it('increments summaryRefreshKey on evidence upload complete', async () => {
@@ -421,8 +448,7 @@ describe('TasksDetailsModal', () => {
     expect(screen.getByText(/txn:E2E-TXN-001/)).toBeInTheDocument();
   });
 
-  it('extracts transactionId from transaction_id field', async () => {
-    const user = userEvent.setup();
+  it('hides Visualizations when only transaction_id field is present', () => {
     const caseWithTxnId: CaseRow = {
       ...mockCaseData,
       transaction: JSON.stringify({
@@ -431,12 +457,10 @@ describe('TasksDetailsModal', () => {
     };
     renderModal({ row: caseWithTxnId });
 
-    await user.click(screen.getByText('Visualizations'));
-    expect(screen.getByText(/txn:SIMPLE-TXN-001/)).toBeInTheDocument();
+    expect(screen.queryByText('Visualizations')).not.toBeInTheDocument();
   });
 
-  it('extracts transactionId from transactionId field', async () => {
-    const user = userEvent.setup();
+  it('hides Visualizations when only transactionId field is present', () => {
     const caseWithTxnId: CaseRow = {
       ...mockCaseData,
       transaction: JSON.stringify({
@@ -445,7 +469,6 @@ describe('TasksDetailsModal', () => {
     };
     renderModal({ row: caseWithTxnId });
 
-    await user.click(screen.getByText('Visualizations'));
-    expect(screen.getByText(/txn:CAMEL-TXN-001/)).toBeInTheDocument();
+    expect(screen.queryByText('Visualizations')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/features/cases/components/__tests__/TasksDetailsModal.test.tsx
+++ b/frontend/src/features/cases/components/__tests__/TasksDetailsModal.test.tsx
@@ -209,6 +209,19 @@ describe('TasksDetailsModal', () => {
     expect(screen.getByText('Investigation Summary')).toBeInTheDocument();
   });
 
+  it('hides Visualizations tab for non-pacs002 transactions', () => {
+    const caseWithNonPacs002: CaseRow = {
+      ...mockCaseData,
+      transaction: JSON.stringify({
+        tx_type: 'pacs.008.001.10',
+      }),
+    };
+
+    renderModal({ row: caseWithNonPacs002 });
+
+    expect(screen.queryByText('Visualizations')).not.toBeInTheDocument();
+  });
+
   it('switches to Evidence tab', async () => {
     const user = userEvent.setup();
     mockGetTasksByCaseId.mockResolvedValue(mockTasks);
@@ -265,7 +278,7 @@ describe('TasksDetailsModal', () => {
   });
 
   it('handles parent case details fetch error', async () => {
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
     mockGetCaseDetails.mockRejectedValue(new Error('fetch failed'));
 
     renderModal({ row: mockCaseWithParent });
@@ -280,7 +293,7 @@ describe('TasksDetailsModal', () => {
   });
 
   it('handles task fetch error gracefully', async () => {
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
     mockGetTasksByCaseId.mockRejectedValue(new Error('task fetch failed'));
 
     renderModal({});


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Updated the Visualization tab logic to display only for PACS.002 transactions instead of showing it by default for most transaction types.

## Why are we doing this?
This ensures visualizations are only available when supported by the underlying transaction data, improving UI accuracy and preventing unnecessary component loading.

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done
