### PR TITLE
fix(ci): backport Slack Docker notification source-PR and image-link updates [skip ci]

### DIFF
--- a/.github/workflows/dockerhub-image-build-dual-rc.yml
+++ b/.github/workflows/dockerhub-image-build-dual-rc.yml
@@ -73,12 +73,25 @@ jobs:
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: false  # RC builds: attestation generated locally only; not pushed to sigstore transparency log
 
+      - name: Resolve source PR
+        id: src_pr
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_URL=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" --jq '.[0].html_url // empty' 2>/dev/null || true)
+          PR_FIELD=""
+          if [ -n "$PR_URL" ]; then
+            PR_FIELD=$(printf ',{"type": "mrkdwn","text": "*Source PR:*\\n<%s>"}' "$PR_URL")
+          fi
+          echo "PR_FIELD=${PR_FIELD}" >> "$GITHUB_OUTPUT"
+
       - name: Send Slack Notification
         continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Release Candidate Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-backend "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/orgs/tazamaorg/repositories>"}]}]}' $SLACK_WEBHOOK_URL
+          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Release Candidate Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-backend "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/r/tazamaorg/${{ env.REPO_NAME }}-backend>"}${{ steps.src_pr.outputs.PR_FIELD }}]}]}' $SLACK_WEBHOOK_URL
 
   push_migrate_rc:
     if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
@@ -131,12 +144,25 @@ jobs:
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: false  # RC builds: attestation generated locally only; not pushed to sigstore transparency log
 
+      - name: Resolve source PR
+        id: src_pr
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_URL=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" --jq '.[0].html_url // empty' 2>/dev/null || true)
+          PR_FIELD=""
+          if [ -n "$PR_URL" ]; then
+            PR_FIELD=$(printf ',{"type": "mrkdwn","text": "*Source PR:*\\n<%s>"}' "$PR_URL")
+          fi
+          echo "PR_FIELD=${PR_FIELD}" >> "$GITHUB_OUTPUT"
+
       - name: Send Slack Notification
         continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Release Candidate Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-migrate "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/orgs/tazamaorg/repositories>"}]}]}' $SLACK_WEBHOOK_URL
+          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Release Candidate Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-migrate "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/r/tazamaorg/${{ env.REPO_NAME }}-migrate>"}${{ steps.src_pr.outputs.PR_FIELD }}]}]}' $SLACK_WEBHOOK_URL
 
   push_frontend_rc:
     if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
@@ -188,12 +214,25 @@ jobs:
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: false  # RC builds: attestation generated locally only; not pushed to sigstore transparency log
 
+      - name: Resolve source PR
+        id: src_pr
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_URL=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" --jq '.[0].html_url // empty' 2>/dev/null || true)
+          PR_FIELD=""
+          if [ -n "$PR_URL" ]; then
+            PR_FIELD=$(printf ',{"type": "mrkdwn","text": "*Source PR:*\\n<%s>"}' "$PR_URL")
+          fi
+          echo "PR_FIELD=${PR_FIELD}" >> "$GITHUB_OUTPUT"
+
       - name: Send Slack Notification
         continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Release Candidate Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-frontend "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/orgs/tazamaorg/repositories>"}]}]}' $SLACK_WEBHOOK_URL
+          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Release Candidate Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-frontend "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/r/tazamaorg/${{ env.REPO_NAME }}-frontend>"}${{ steps.src_pr.outputs.PR_FIELD }}]}]}' $SLACK_WEBHOOK_URL
 
   push_voila_rc:
     if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
@@ -243,9 +282,22 @@ jobs:
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: false  # RC builds: attestation generated locally only; not pushed to sigstore transparency log
 
+      - name: Resolve source PR
+        id: src_pr
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_URL=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" --jq '.[0].html_url // empty' 2>/dev/null || true)
+          PR_FIELD=""
+          if [ -n "$PR_URL" ]; then
+            PR_FIELD=$(printf ',{"type": "mrkdwn","text": "*Source PR:*\\n<%s>"}' "$PR_URL")
+          fi
+          echo "PR_FIELD=${PR_FIELD}" >> "$GITHUB_OUTPUT"
+
       - name: Send Slack Notification
         continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Release Candidate Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-voila "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/orgs/tazamaorg/repositories>"}]}]}' $SLACK_WEBHOOK_URL
+          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Release Candidate Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-voila "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/r/tazamaorg/${{ env.REPO_NAME }}-voila>"}${{ steps.src_pr.outputs.PR_FIELD }}]}]}' $SLACK_WEBHOOK_URL

--- a/.github/workflows/dockerhub-image-build-dual.yml
+++ b/.github/workflows/dockerhub-image-build-dual.yml
@@ -78,12 +78,25 @@ jobs:
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
 
+      - name: Resolve source PR
+        id: src_pr
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_URL=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" --jq '.[0].html_url // empty' 2>/dev/null || true)
+          PR_FIELD=""
+          if [ -n "$PR_URL" ]; then
+            PR_FIELD=$(printf ',{"type": "mrkdwn","text": "*Source PR:*\\n<%s>"}' "$PR_URL")
+          fi
+          echo "PR_FIELD=${PR_FIELD}" >> "$GITHUB_OUTPUT"
+
       - name: Send Slack Notification
         continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-backend "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/orgs/tazamaorg/repositories>"}]}]}' $SLACK_WEBHOOK_URL
+          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-backend "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/r/tazamaorg/${{ env.REPO_NAME }}-backend>"}${{ steps.src_pr.outputs.PR_FIELD }}]}]}' $SLACK_WEBHOOK_URL
 
   push_migrate:
     if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
@@ -140,12 +153,25 @@ jobs:
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
 
+      - name: Resolve source PR
+        id: src_pr
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_URL=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" --jq '.[0].html_url // empty' 2>/dev/null || true)
+          PR_FIELD=""
+          if [ -n "$PR_URL" ]; then
+            PR_FIELD=$(printf ',{"type": "mrkdwn","text": "*Source PR:*\\n<%s>"}' "$PR_URL")
+          fi
+          echo "PR_FIELD=${PR_FIELD}" >> "$GITHUB_OUTPUT"
+
       - name: Send Slack Notification
         continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-migrate "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/orgs/tazamaorg/repositories>"}]}]}' $SLACK_WEBHOOK_URL
+          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-migrate "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/r/tazamaorg/${{ env.REPO_NAME }}-migrate>"}${{ steps.src_pr.outputs.PR_FIELD }}]}]}' $SLACK_WEBHOOK_URL
 
   push_frontend:
     if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
@@ -201,12 +227,25 @@ jobs:
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
 
+      - name: Resolve source PR
+        id: src_pr
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_URL=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" --jq '.[0].html_url // empty' 2>/dev/null || true)
+          PR_FIELD=""
+          if [ -n "$PR_URL" ]; then
+            PR_FIELD=$(printf ',{"type": "mrkdwn","text": "*Source PR:*\\n<%s>"}' "$PR_URL")
+          fi
+          echo "PR_FIELD=${PR_FIELD}" >> "$GITHUB_OUTPUT"
+
       - name: Send Slack Notification
         continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-frontend "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/orgs/tazamaorg/repositories>"}]}]}' $SLACK_WEBHOOK_URL
+          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-frontend "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/r/tazamaorg/${{ env.REPO_NAME }}-frontend>"}${{ steps.src_pr.outputs.PR_FIELD }}]}]}' $SLACK_WEBHOOK_URL
 
   push_voila:
     if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
@@ -260,9 +299,22 @@ jobs:
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
 
+      - name: Resolve source PR
+        id: src_pr
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_URL=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" --jq '.[0].html_url // empty' 2>/dev/null || true)
+          PR_FIELD=""
+          if [ -n "$PR_URL" ]; then
+            PR_FIELD=$(printf ',{"type": "mrkdwn","text": "*Source PR:*\\n<%s>"}' "$PR_URL")
+          fi
+          echo "PR_FIELD=${PR_FIELD}" >> "$GITHUB_OUTPUT"
+
       - name: Send Slack Notification
         continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
-          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-voila "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/orgs/tazamaorg/repositories>"}]}]}' $SLACK_WEBHOOK_URL
+          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{"blocks": [{"type": "header","text": {"type": "plain_text","text": "New Dockerhub Image published :ship::ship:","emoji": true}},{"type": "section","fields": [{"type": "mrkdwn","text": "*Service:*\n${{ env.REPO_NAME }}-voila "},{"type": "mrkdwn","text": "*Tazama Dockerhub:*\n<https://hub.docker.com/r/tazamaorg/${{ env.REPO_NAME }}-voila>"}${{ steps.src_pr.outputs.PR_FIELD }}]}]}' $SLACK_WEBHOOK_URL


### PR DESCRIPTION
## Summary
Backports the Slack Docker notification improvements from workflows PR #143 into this repo's dual image publish workflows.

## Changes
- Added `Resolve source PR` step in both workflow files for each publish job.
- Changed DockerHub link from org listing to image-specific repository URL.
- Added conditional `Source PR` field in Slack message payload.
- Kept notification and PR-resolution steps non-fatal.

## Files
- `.github/workflows/dockerhub-image-build-dual.yml`
- `.github/workflows/dockerhub-image-build-dual-rc.yml`

## Verification
- Confirmed all org-level DockerHub URLs are removed.
- Confirmed Source PR field injection exists for each Slack notification block.

Refs #191
