### PR TITLE
fix: Move Visualization Tab

### DIFF
--- a/backend/src/modules/gold-lakehouse/transaction-lakehouse.service.ts
+++ b/backend/src/modules/gold-lakehouse/transaction-lakehouse.service.ts
@@ -134,11 +134,14 @@ export class TransactionLakehouseService extends GoldLakehouseService {
         amountAndCurrency: [
           {
             originalAmount: Number(pacs8.instructed_amount) || 0,
+            originalCurrency: String(pacs8.instructed_currency) || 'USD',
             exchangeRate: Number(pacs8.exchange_rate) || 1,
             convertedAmount: Number(pacs8.interbank_settlement_amount) || 0,
+            convertedCurrency: String(pacs8.interbank_settlement_currency) || 'USD',
           },
           {
             totalCharges: Number(pacs8.charge_total_amount),
+            chargeCurrency: String(pacs8.charge_currency) || 'USD',
           },
         ],
         settlementDetails: {

--- a/backend/src/modules/gold-lakehouse/types/transaction-detail.types.ts
+++ b/backend/src/modules/gold-lakehouse/types/transaction-detail.types.ts
@@ -48,11 +48,14 @@ export interface TransactionDetailDataResponse {
   amountAndCurrency: Array<
     | {
         originalAmount: number;
+        originalCurrency: string;
         exchangeRate: number;
         convertedAmount: number;
+        convertedCurrency: string;
       }
     | {
         totalCharges: number;
+        chargeCurrency: string;
       }
   >;
   settlementDetails: {

--- a/frontend/src/features/cases/components/TasksDetailsModal.tsx
+++ b/frontend/src/features/cases/components/TasksDetailsModal.tsx
@@ -6,15 +6,11 @@ import TaskEvidenceTab from './view/TaskEvidenceTab';
 import InvestigationNotesTab from './view/InvestigationNotesTab';
 import InvestigationSummaryTab from './view/InvestigationsSummaryTab';
 import TaskDetailsTab from './view/TaskDetailsTab';
-import VisualizationsTab from './view/VisualizationsTab';
 import { taskService, type TaskForSupervisor } from '../services/taskService';
-import { caseService } from '../services/caseService';
-import type { Case } from '@/features/alerts/types/triage.types';
 
 type ViewTabKey =
   | 'details'
   | 'evidence'
-  | 'visualizations'
   | 'tasks'
   | 'notes'
   | 'customer'
@@ -43,40 +39,9 @@ const TaskDetailsModal: React.FC<TaskDetailsModalProps> = ({
   const [showCollaborate, setShowCollaborate] = React.useState(false);
   const [tasks, setTasks] = React.useState<TaskForSupervisor[]>([]);
   const [loadingTasks, setLoadingTasks] = React.useState(false);
-  const [parentAlertId, setParentAlertId] = React.useState<number | undefined>(
-    undefined,
-  );
-  const [parentCaseDetails, setParentCaseDetails] = React.useState<
-    Case | undefined
-  >(undefined);
-  const [isParentCaseLoading, setIsParentCaseLoading] = React.useState(false);
 
   const [summaryRefreshKey, setSummaryRefreshKey] = React.useState(0);
   const initialCaseIdRef = React.useRef<number | undefined>(undefined);
-
-  React.useEffect(() => {
-    if (row?.parentId) {
-      setIsParentCaseLoading(true);
-      caseService
-        .getCaseDetails(row.parentId)
-        .then((details) => {
-          setParentAlertId(details.alert.alert_id);
-          setParentCaseDetails(details);
-        })
-        .catch((error) => {
-          console.error('Failed to fetch case details for parent case:', error);
-          setParentAlertId(undefined);
-          setParentCaseDetails(undefined);
-        })
-        .finally(() => {
-          setIsParentCaseLoading(false);
-        });
-    } else {
-      setParentAlertId(undefined);
-      setParentCaseDetails(undefined);
-      setIsParentCaseLoading(false);
-    }
-  }, [row?.parentId]);
 
   React.useEffect(() => {
     if (open) {
@@ -119,84 +84,6 @@ const TaskDetailsModal: React.FC<TaskDetailsModalProps> = ({
     }
   }, [row?.id, open, onClose]);
 
-  //Extract transaction ID from transaction data
-  const transactionId = React.useMemo(() => {
-    if (row?.parentId && isParentCaseLoading) {
-      // Wait for parent details before deciding visibility to avoid tab flicker.
-      return undefined;
-    }
-
-    let transactionData = row?.parentId
-      ? parentCaseDetails?.alert.transaction
-      : row?.transaction;
-
-    if (!transactionData) {
-      return undefined;
-    }
-
-    // Check if transaction is a string that needs parsing
-    if (typeof transactionData === 'string') {
-      try {
-        transactionData = JSON.parse(transactionData);
-      } catch (e) {
-        return undefined;
-      }
-    }
-
-    const transaction = transactionData as Record<string, unknown>;
-
-    const fiToFIPmtSts = transaction?.FIToFIPmtSts as
-      | Record<string, unknown>
-      | undefined;
-    const txInfAndSts = fiToFIPmtSts?.TxInfAndSts as
-      | Record<string, unknown>
-      | undefined;
-
-    // Try multiple possible field locations
-    const extractedId =
-      txInfAndSts?.OrgnlEndToEndId ||
-      txInfAndSts?.EndToEndId ||
-      transaction?.transaction_id ||
-      transaction?.transactionId;
-
-    if (extractedId && typeof extractedId === 'string') {
-      return extractedId;
-    }
-
-    return undefined;
-  }, [row, parentCaseDetails, isParentCaseLoading]);
-
-  const shouldShowVisualizations = React.useMemo(() => {
-    if (row?.parentId && isParentCaseLoading) {
-      return false;
-    }
-
-    let transactionData = row?.parentId
-      ? parentCaseDetails?.alert.transaction
-      : row?.transaction;
-
-    if (!transactionData) {
-      return false;
-    }
-
-    if (typeof transactionData === 'string') {
-      try {
-        transactionData = JSON.parse(transactionData);
-      } catch (e) {
-        return false;
-      }
-    }
-
-    const transaction = transactionData as Record<string, unknown>;
-    return transaction?.FIToFIPmtSts !== undefined;
-  }, [row, parentCaseDetails, isParentCaseLoading]);
-
-  React.useEffect(() => {
-    if (shouldShowVisualizations === false && tab === 'visualizations') {
-      setTab('details');
-    }
-  }, [shouldShowVisualizations, tab]);
-
   if (!open || !row) return null;
 
   return (
@@ -225,14 +112,6 @@ const TaskDetailsModal: React.FC<TaskDetailsModalProps> = ({
               [
                 { key: 'details', label: 'Task Details' },
                 { key: 'evidence', label: 'Evidence' },
-                ...(shouldShowVisualizations === true
-                  ? ([
-                    {
-                      key: 'visualizations',
-                      label: 'Visualizations',
-                    },
-                  ] as const)
-                  : []),
                 { key: 'notes', label: 'Investigation Notes' },
                 { key: 'summary', label: 'Investigation Summary' },
               ] satisfies Array<{ key: ViewTabKey; label: string }>
@@ -279,19 +158,6 @@ const TaskDetailsModal: React.FC<TaskDetailsModalProps> = ({
                   }}
                 />
               </div>
-              {shouldShowVisualizations === true && (
-                <div
-                  style={{
-                    display: tab === 'visualizations' ? 'block' : 'none',
-                  }}
-                >
-                  <VisualizationsTab
-                    alertId={row?.parentId ? parentAlertId : row?.alertId}
-                    caseId={row?.id}
-                    transactionId={transactionId}
-                  />
-                </div>
-              )}
               <div style={{ display: tab === 'notes' ? 'block' : 'none' }}>
                 <InvestigationNotesTab
                   task={tasks.filter((t) => t.task_id === selectedTask?.id)[0]}

--- a/frontend/src/features/cases/components/ViewCaseModal.tsx
+++ b/frontend/src/features/cases/components/ViewCaseModal.tsx
@@ -11,8 +11,15 @@ import CaseActionsPanel from './view/CaseActionsPanel';
 import { caseService, type CaseWithTasksDto } from '../services/caseService';
 import { transformBackendCaseToUI } from './casesTable.utils';
 import LinkedItemsTab from './view/LinkedItemsTab';
+import VisualizationsTab from './view/VisualizationsTab';
 
-type ViewTabKey = 'details' | 'tasks' | 'linked' | 'history' | 'comments';
+type ViewTabKey =
+  | 'details'
+  | 'tasks'
+  | 'linked'
+  | 'visualizations'
+  | 'history'
+  | 'comments';
 
 interface ViewCaseModalProps {
   open: boolean;
@@ -63,6 +70,13 @@ const ViewCaseModal: React.FC<ViewCaseModalProps> = ({
   );
   const [subCases, setSubCases] = React.useState<CaseRow[]>([]);
   const [parentCase, setparentCase] = React.useState<CaseRow | null>(null);
+  // const [parentAlertId, setParentAlertId] = React.useState<number | undefined>(
+  //   undefined,
+  // );
+  // const [parentCaseDetails, setParentCaseDetails] = React.useState<
+  //   Case | undefined
+  // >(undefined);
+  const [isParentCaseLoading, setIsParentCaseLoading] = React.useState(false);
 
   // Initialize local case data when row changes
   React.useEffect(() => {
@@ -96,6 +110,7 @@ const ViewCaseModal: React.FC<ViewCaseModalProps> = ({
   const getParentCaseData = React.useCallback(async () => {
     if (!row?.id || !row?.parentId) return;
     try {
+      setIsParentCaseLoading(true);
       const caseDetails = await caseService.getCaseDetails(row.parentId);
       const transformedCase = transformBackendCaseToUI(
         caseDetails as unknown as CaseWithTasksDto,
@@ -103,6 +118,8 @@ const ViewCaseModal: React.FC<ViewCaseModalProps> = ({
       setparentCase(transformedCase);
     } catch (error) {
       console.error('Failed to refresh case data:', error);
+    } finally {
+      setIsParentCaseLoading(false);
     }
   }, [row?.id, row?.parentId]);
 
@@ -136,6 +153,113 @@ const ViewCaseModal: React.FC<ViewCaseModalProps> = ({
     }
   }, [open, localCaseData, getSubCasesData, getParentCaseData]);
 
+  // Fetch parent case details for alert/transaction data (for sub-cases)
+  // React.useEffect(() => {
+  //   if (row?.parentId) {
+  //     setIsParentCaseLoading(true);
+  //     caseService
+  //       .getCaseDetails(row.parentId)
+  //       .then((details) => {
+  //         setParentAlertId(details.alert.alert_id);
+  //         setParentCaseDetails(details);
+  //       })
+  //       .catch((error) => {
+  //         console.error('Failed to fetch case details for parent case:', error);
+  //         setParentAlertId(undefined);
+  //         setParentCaseDetails(undefined);
+  //       })
+  //       .finally(() => {
+  //         setIsParentCaseLoading(false);
+  //       });
+  //   } else {
+  //     setParentAlertId(undefined);
+  //     setParentCaseDetails(undefined);
+  //     setIsParentCaseLoading(false);
+  //   }
+  // }, [row?.parentId]);
+
+  // Extract transaction ID from transaction data
+  const transactionId = React.useMemo(() => {
+    const currentRow = localCaseData;
+    if (!currentRow) return undefined;
+
+    if (currentRow?.parentId && isParentCaseLoading) {
+      return undefined;
+    }
+
+    let transactionData = currentRow?.parentId
+      ? parentCase?.transaction
+      : currentRow?.transaction;
+
+    if (!transactionData) {
+      return undefined;
+    }
+
+    if (typeof transactionData === 'string') {
+      try {
+        transactionData = JSON.parse(transactionData);
+      } catch (e) {
+        return undefined;
+      }
+    }
+
+    const transaction = transactionData as Record<string, unknown>;
+
+    const fiToFIPmtSts = transaction?.FIToFIPmtSts as
+      | Record<string, unknown>
+      | undefined;
+    const txInfAndSts = fiToFIPmtSts?.TxInfAndSts as
+      | Record<string, unknown>
+      | undefined;
+
+    const extractedId =
+      txInfAndSts?.OrgnlEndToEndId ||
+      txInfAndSts?.EndToEndId ||
+      transaction?.transaction_id ||
+      transaction?.transactionId;
+
+    if (extractedId && typeof extractedId === 'string') {
+      return extractedId;
+    }
+
+    return undefined;
+  }, [localCaseData, parentCase, isParentCaseLoading]);
+
+  const shouldShowVisualizations = React.useMemo(() => {
+    const currentRow = localCaseData;
+    if (!currentRow) return false;
+
+    if (currentRow?.parentId && isParentCaseLoading) {
+      return false;
+    }
+
+    let transactionData = currentRow?.parentId
+      ? parentCase?.transaction
+      : currentRow?.transaction;
+
+    if (!transactionData) {
+      return false;
+    }
+
+    if (typeof transactionData === 'string') {
+      try {
+        transactionData = JSON.parse(transactionData);
+      } catch (e) {
+        return false;
+      }
+    }
+
+    const transaction = transactionData as Record<string, unknown>;
+    return transaction?.FIToFIPmtSts !== undefined;
+  }, [localCaseData, parentCase, isParentCaseLoading]);
+
+  // Switch away from visualizations tab if it becomes hidden
+  React.useEffect(() => {
+    if (shouldShowVisualizations === false && tab === 'visualizations') {
+      setTab('details');
+    }
+  }, [shouldShowVisualizations, tab]);
+
   if (!open || !localCaseData) return null;
 
   const displayData = localCaseData;
@@ -167,6 +291,14 @@ const ViewCaseModal: React.FC<ViewCaseModalProps> = ({
                 { key: 'details', label: 'Case Details' },
                 { key: 'tasks', label: 'Task Log' },
                 { key: 'linked', label: 'Linked Items' },
+                ...(shouldShowVisualizations === true
+                  ? ([
+                    {
+                      key: 'visualizations',
+                      label: 'Visualizations',
+                    },
+                  ] as const)
+                  : []),
                 { key: 'history', label: 'Case History' },
                 { key: 'comments', label: 'Comments History' },
               ] satisfies Array<{ key: ViewTabKey; label: string }>
@@ -240,6 +372,16 @@ const ViewCaseModal: React.FC<ViewCaseModalProps> = ({
                   caseId={displayData.id}
                 />
               )}
+              {shouldShowVisualizations === true &&
+                tab === 'visualizations' && (
+                  <VisualizationsTab
+                    alertId={
+                      displayData?.parentId ? parentCase?.alertId : displayData?.alertId
+                    }
+                    caseId={displayData?.id}
+                    transactionId={transactionId}
+                  />
+                )}
               {tab === 'comments' && (
                 <CommentHistoryTab caseId={displayData.id} />
               )}

--- a/frontend/src/features/cases/components/__tests__/TasksDetailsModal.test.tsx
+++ b/frontend/src/features/cases/components/__tests__/TasksDetailsModal.test.tsx
@@ -42,12 +42,6 @@ vi.mock('../view/CollaboratePanel', () => ({
   default: () => <div>Collaborate Panel</div>,
 }));
 
-vi.mock('../view/VisualizationsTab', () => ({
-  default: ({ transactionId }: any) => (
-    <div>Visualizations Tab {transactionId && `txn:${transactionId}`}</div>
-  ),
-}));
-
 vi.mock('../view/InvestigationsSummaryTab', () => ({
   default: ({ onTaskUpdate }: any) => (
     <div>
@@ -76,17 +70,10 @@ vi.mock('@/shared/providers/ToastProvider', () => ({
 import TasksDetailsModal from '../TasksDetailsModal';
 
 const mockGetTasksByCaseId = vi.fn();
-const mockGetCaseDetails = vi.fn();
 
 vi.mock('../../services/taskService', () => ({
   taskService: {
     getTasksByCaseId: (...args: any[]) => mockGetTasksByCaseId(...args),
-  },
-}));
-
-vi.mock('../../services/caseService', () => ({
-  caseService: {
-    getCaseDetails: (...args: any[]) => mockGetCaseDetails(...args),
   },
 }));
 
@@ -115,11 +102,6 @@ const mockCaseData: CaseRow = {
   }),
 };
 
-const mockCaseWithParent: CaseRow = {
-  ...mockCaseData,
-  parentId: 999,
-};
-
 const mockTasks = [
   {
     task_id: 'TASK-1',
@@ -137,9 +119,6 @@ describe('TasksDetailsModal', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetTasksByCaseId.mockResolvedValue([]);
-    mockGetCaseDetails.mockResolvedValue({
-      alert: { alert_id: 42, transaction: null },
-    });
   });
 
   const renderModal = (
@@ -200,21 +179,12 @@ describe('TasksDetailsModal', () => {
     renderModal({});
     expect(screen.getAllByText('Task Details')[0]).toBeInTheDocument();
     expect(screen.getByText('Evidence')).toBeInTheDocument();
-    expect(screen.getByText('Visualizations')).toBeInTheDocument();
     expect(screen.getByText('Investigation Notes')).toBeInTheDocument();
     expect(screen.getByText('Investigation Summary')).toBeInTheDocument();
   });
 
-  it('hides Visualizations tab for non-pacs002 transactions', () => {
-    const caseWithNonPacs002: CaseRow = {
-      ...mockCaseData,
-      transaction: JSON.stringify({
-        TxTp: 'pacs.008.001.10',
-      }),
-    };
-
-    renderModal({ row: caseWithNonPacs002 });
-
+  it('does not render Visualizations tab', () => {
+    renderModal({});
     expect(screen.queryByText('Visualizations')).not.toBeInTheDocument();
   });
 
@@ -225,14 +195,6 @@ describe('TasksDetailsModal', () => {
 
     await user.click(screen.getByText('Evidence'));
     expect(screen.getByText('Task Evidence Tab')).toBeInTheDocument();
-  });
-
-  it('switches to Visualizations tab', async () => {
-    const user = userEvent.setup();
-    renderModal({});
-
-    await user.click(screen.getByText('Visualizations'));
-    expect(screen.getByText(/Visualizations Tab/)).toBeInTheDocument();
   });
 
   it('switches to Investigation Notes tab', async () => {
@@ -253,64 +215,6 @@ describe('TasksDetailsModal', () => {
     expect(screen.getByText('Investigation Summary Tab')).toBeInTheDocument();
   });
 
-  it('fetches parent case details when parentId exists', async () => {
-    mockGetCaseDetails.mockResolvedValue({
-      alert: { alert_id: 42, transaction: '{"data":"test"}' },
-    });
-
-    renderModal({ row: mockCaseWithParent });
-
-    await waitFor(() => {
-      expect(mockGetCaseDetails).toHaveBeenCalledWith(999);
-    });
-  });
-
-  it('defers Visualizations tab visibility until parent case details finish loading', async () => {
-    let resolveParentCase: ((value: unknown) => void) | undefined;
-    mockGetCaseDetails.mockImplementation(
-      () =>
-        new Promise((resolve) => {
-          resolveParentCase = resolve;
-        }),
-    );
-
-    renderModal({ row: mockCaseWithParent });
-
-    expect(screen.queryByText('Visualizations')).not.toBeInTheDocument();
-
-    resolveParentCase?.({
-      alert: {
-        alert_id: 42,
-        transaction: JSON.stringify({
-          FIToFIPmtSts: {
-            TxInfAndSts: {
-              OrgnlEndToEndId: 'PARENT-TXN-001',
-            },
-          },
-        }),
-      },
-    });
-
-    await waitFor(() => {
-      expect(screen.getByText('Visualizations')).toBeInTheDocument();
-    });
-  });
-
-  it('handles parent case details fetch error', async () => {
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
-    mockGetCaseDetails.mockRejectedValue(new Error('fetch failed'));
-
-    renderModal({ row: mockCaseWithParent });
-
-    await waitFor(() => {
-      expect(consoleSpy).toHaveBeenCalledWith(
-        'Failed to fetch case details for parent case:',
-        expect.any(Error),
-      );
-    });
-    consoleSpy.mockRestore();
-  });
-
   it('handles task fetch error gracefully', async () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
     mockGetTasksByCaseId.mockRejectedValue(new Error('task fetch failed'));
@@ -324,61 +228,6 @@ describe('TasksDetailsModal', () => {
       );
     });
     consoleSpy.mockRestore();
-  });
-
-  it('extracts transactionId from row transaction data', async () => {
-    const user = userEvent.setup();
-    renderModal({});
-
-    await user.click(screen.getByText('Visualizations'));
-    expect(screen.getByText(/txn:TXN-12345/)).toBeInTheDocument();
-  });
-
-  it('extracts transactionId from parent case transaction data', async () => {
-    mockGetCaseDetails.mockResolvedValue({
-      alert: {
-        alert_id: 42,
-        transaction: JSON.stringify({
-          FIToFIPmtSts: {
-            TxInfAndSts: {
-              OrgnlEndToEndId: 'PARENT-TXN-001',
-            },
-          },
-        }),
-      },
-    });
-
-    const user = userEvent.setup();
-    renderModal({ row: mockCaseWithParent });
-
-    await waitFor(() => {
-      expect(mockGetCaseDetails).toHaveBeenCalledWith(999);
-    });
-
-    await user.click(screen.getByText('Visualizations'));
-    await waitFor(() => {
-      expect(screen.getByText(/txn:PARENT-TXN-001/)).toBeInTheDocument();
-    });
-  });
-
-  it('hides Visualizations when transaction data is invalid JSON', () => {
-    const caseWithBadTransaction: CaseRow = {
-      ...mockCaseData,
-      transaction: 'invalid json{{{',
-    };
-    renderModal({ row: caseWithBadTransaction });
-
-    expect(screen.queryByText('Visualizations')).not.toBeInTheDocument();
-  });
-
-  it('hides Visualizations when transaction is null', () => {
-    const caseWithNoTransaction: CaseRow = {
-      ...mockCaseData,
-      transaction: undefined,
-    };
-    renderModal({ row: caseWithNoTransaction });
-
-    expect(screen.queryByText('Visualizations')).not.toBeInTheDocument();
   });
 
   it('increments summaryRefreshKey on evidence upload complete', async () => {
@@ -418,45 +267,42 @@ describe('TasksDetailsModal', () => {
     expect(mockGetTasksByCaseId).toHaveBeenCalledTimes(2); // once on open, once on refresh
   });
 
-  it('extracts transactionId from EndToEndId field', async () => {
-    const user = userEvent.setup();
-    const caseWithEndToEnd: CaseRow = {
-      ...mockCaseData,
-      transaction: JSON.stringify({
-        FIToFIPmtSts: {
-          TxInfAndSts: {
-            EndToEndId: 'E2E-TXN-001',
-          },
-        },
-      }),
-    };
-    renderModal({ row: caseWithEndToEnd });
+  it('closes modal when navigating to a different case', async () => {
+    const { rerender } = renderModal({});
 
-    await user.click(screen.getByText('Visualizations'));
-    expect(screen.getByText(/txn:E2E-TXN-001/)).toBeInTheDocument();
+    // Re-render with a different case id
+    rerender(
+      <TasksDetailsModal
+        open={true}
+        onClose={mockOnClose}
+        row={{ ...mockCaseData, id: 456 }}
+        selectedTask={{ id: 'TASK-1' }}
+        onRefreshCases={mockOnRefreshCases}
+        onTaskUpdate={mockOnTaskUpdate}
+      />,
+    );
+
+    expect(mockOnClose).toHaveBeenCalled();
   });
 
-  it('hides Visualizations when only transaction_id field is present', () => {
-    const caseWithTxnId: CaseRow = {
-      ...mockCaseData,
-      transaction: JSON.stringify({
-        transaction_id: 'SIMPLE-TXN-001',
-      }),
-    };
-    renderModal({ row: caseWithTxnId });
-
-    expect(screen.queryByText('Visualizations')).not.toBeInTheDocument();
+  it('does not fetch tasks when modal is closed', () => {
+    renderModal({ open: false });
+    expect(mockGetTasksByCaseId).not.toHaveBeenCalled();
   });
 
-  it('hides Visualizations when only transactionId field is present', () => {
-    const caseWithTxnId: CaseRow = {
-      ...mockCaseData,
-      transaction: JSON.stringify({
-        transactionId: 'CAMEL-TXN-001',
-      }),
-    };
-    renderModal({ row: caseWithTxnId });
+  it('does not fetch tasks when row has no id', () => {
+    renderModal({ row: { ...mockCaseData, id: undefined as any } });
+    expect(mockGetTasksByCaseId).not.toHaveBeenCalled();
+  });
 
-    expect(screen.queryByText('Visualizations')).not.toBeInTheDocument();
+  it('renders Task Details tab content by default', () => {
+    renderModal({});
+    expect(screen.getByText('Task Details Tab')).toBeInTheDocument();
+  });
+
+  it('renders close button at the bottom', async () => {
+    renderModal({});
+    const closeButtons = screen.getAllByRole('button', { name: /Close/i });
+    expect(closeButtons.length).toBeGreaterThanOrEqual(2);
   });
 });

--- a/frontend/src/features/cases/components/__tests__/ViewCaseModal.test.tsx
+++ b/frontend/src/features/cases/components/__tests__/ViewCaseModal.test.tsx
@@ -66,6 +66,12 @@ vi.mock('../view/CaseActionsPanel', () => ({
   default: () => <div>Case Actions Panel</div>,
 }));
 
+vi.mock('../view/VisualizationsTab', () => ({
+  default: ({ transactionId }: any) => (
+    <div>Visualizations Tab {transactionId && `txn:${transactionId}`}</div>
+  ),
+}));
+
 import ViewCaseModal from '../ViewCaseModal';
 
 const mockCaseData: CaseRow = {
@@ -405,5 +411,455 @@ describe('ViewCaseModal', () => {
     );
 
     expect(screen.getByText('Task Log')).toBeInTheDocument();
+  });
+
+  // ─── Visualizations tab tests ────────────────────────────────────────
+
+  it('does not show Visualizations tab when row has no transaction', () => {
+    const caseNoTxn: CaseRow = { ...mockCaseData, transaction: undefined };
+    render(
+      <ViewCaseModal
+        open={true}
+        onClose={mockOnClose}
+        row={caseNoTxn}
+        onRefreshCases={mockOnRefreshCases}
+      />,
+    );
+    expect(screen.queryByText('Visualizations')).not.toBeInTheDocument();
+  });
+
+  it('does not show Visualizations tab when transaction has no FIToFIPmtSts', () => {
+    const caseNonPacs: CaseRow = {
+      ...mockCaseData,
+      transaction: JSON.stringify({ TxTp: 'pacs.008.001.10' }),
+    };
+    render(
+      <ViewCaseModal
+        open={true}
+        onClose={mockOnClose}
+        row={caseNonPacs}
+        onRefreshCases={mockOnRefreshCases}
+      />,
+    );
+    expect(screen.queryByText('Visualizations')).not.toBeInTheDocument();
+  });
+
+  it('shows Visualizations tab when transaction has FIToFIPmtSts', () => {
+    const caseWithPacs: CaseRow = {
+      ...mockCaseData,
+      transaction: JSON.stringify({
+        FIToFIPmtSts: { TxInfAndSts: { OrgnlEndToEndId: 'TXN-001' } },
+      }),
+    };
+    render(
+      <ViewCaseModal
+        open={true}
+        onClose={mockOnClose}
+        row={caseWithPacs}
+        onRefreshCases={mockOnRefreshCases}
+      />,
+    );
+    expect(screen.getByText('Visualizations')).toBeInTheDocument();
+  });
+
+  it('switches to Visualizations tab and renders transactionId from row', async () => {
+    const user = userEvent.setup();
+    const caseWithPacs: CaseRow = {
+      ...mockCaseData,
+      transaction: JSON.stringify({
+        FIToFIPmtSts: { TxInfAndSts: { OrgnlEndToEndId: 'TXN-001' } },
+      }),
+    };
+    render(
+      <ViewCaseModal
+        open={true}
+        onClose={mockOnClose}
+        row={caseWithPacs}
+        onRefreshCases={mockOnRefreshCases}
+      />,
+    );
+
+    await user.click(screen.getByText('Visualizations'));
+    expect(screen.getByText(/txn:TXN-001/)).toBeInTheDocument();
+  });
+
+  it('falls back to EndToEndId when OrgnlEndToEndId is missing', async () => {
+    const user = userEvent.setup();
+    const caseWithE2E: CaseRow = {
+      ...mockCaseData,
+      transaction: JSON.stringify({
+        FIToFIPmtSts: { TxInfAndSts: { EndToEndId: 'E2E-TXN' } },
+      }),
+    };
+    render(
+      <ViewCaseModal
+        open={true}
+        onClose={mockOnClose}
+        row={caseWithE2E}
+        onRefreshCases={mockOnRefreshCases}
+      />,
+    );
+
+    await user.click(screen.getByText('Visualizations'));
+    expect(screen.getByText(/txn:E2E-TXN/)).toBeInTheDocument();
+  });
+
+  it('hides Visualizations tab when transaction is invalid JSON', () => {
+    const caseBadJson: CaseRow = {
+      ...mockCaseData,
+      transaction: 'not valid json{{{',
+    };
+    render(
+      <ViewCaseModal
+        open={true}
+        onClose={mockOnClose}
+        row={caseBadJson}
+        onRefreshCases={mockOnRefreshCases}
+      />,
+    );
+    expect(screen.queryByText('Visualizations')).not.toBeInTheDocument();
+  });
+
+  it('does not extract transactionId when only transaction_id field exists (no FIToFIPmtSts)', () => {
+    const caseTxnId: CaseRow = {
+      ...mockCaseData,
+      transaction: JSON.stringify({ transaction_id: 'SIMPLE' }),
+    };
+    render(
+      <ViewCaseModal
+        open={true}
+        onClose={mockOnClose}
+        row={caseTxnId}
+        onRefreshCases={mockOnRefreshCases}
+      />,
+    );
+
+    // No Visualizations tab since no FIToFIPmtSts
+    expect(screen.queryByText('Visualizations')).not.toBeInTheDocument();
+  });
+
+  it('shows Visualizations tab using parent case transaction data', async () => {
+    const user = userEvent.setup();
+    const parentCaseRow: CaseRow = {
+      ...mockCaseData,
+      id: 999,
+      alertId: 42,
+      transaction: JSON.stringify({
+        FIToFIPmtSts: { TxInfAndSts: { OrgnlEndToEndId: 'PARENT-TXN' } },
+      }),
+    };
+    mockTransformBackendCaseToUI.mockImplementation((c: any) => c);
+    // getParentCaseData will call getCaseDetails and transform
+    mockGetCaseDetails.mockResolvedValue(parentCaseRow);
+
+    const caseWithParent: CaseRow = { ...mockCaseData, parentId: 999 };
+
+    render(
+      <ViewCaseModal
+        open={true}
+        onClose={mockOnClose}
+        row={caseWithParent}
+        onRefreshCases={mockOnRefreshCases}
+      />,
+    );
+
+    // Wait for parent case data to be fetched and transformed
+    await waitFor(() => {
+      expect(mockGetCaseDetails).toHaveBeenCalledWith(999);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Visualizations')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText('Visualizations'));
+    expect(screen.getByText(/txn:PARENT-TXN/)).toBeInTheDocument();
+  });
+
+  it('defers Visualizations tab while parent case is loading', async () => {
+    let resolveParent: ((value: unknown) => void) | undefined;
+    mockGetCaseDetails.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveParent = resolve;
+        }),
+    );
+
+    render(
+      <ViewCaseModal
+        open={true}
+        onClose={mockOnClose}
+        row={{ ...mockCaseData, parentId: 999 }}
+        onRefreshCases={mockOnRefreshCases}
+      />,
+    );
+
+    // Should not show Visualizations while parent is loading
+    expect(screen.queryByText('Visualizations')).not.toBeInTheDocument();
+
+    // Resolve the parent case with transaction data
+    const parentRow: CaseRow = {
+      ...mockCaseData,
+      id: 999,
+      alertId: 42,
+      transaction: JSON.stringify({
+        FIToFIPmtSts: { TxInfAndSts: { OrgnlEndToEndId: 'PARENT-TXN' } },
+      }),
+    };
+    resolveParent?.(parentRow);
+
+    await waitFor(() => {
+      expect(screen.getByText('Visualizations')).toBeInTheDocument();
+    });
+  });
+
+  it('uses parentCase.alertId when row has parentId for VisualizationsTab', async () => {
+    const parentRow: CaseRow = {
+      ...mockCaseData,
+      id: 999,
+      alertId: 42,
+      transaction: JSON.stringify({
+        FIToFIPmtSts: { TxInfAndSts: { OrgnlEndToEndId: 'PARENT-TXN' } },
+      }),
+    };
+    mockTransformBackendCaseToUI.mockImplementation((c: any) => c);
+    mockGetCaseDetails.mockResolvedValue(parentRow);
+
+    render(
+      <ViewCaseModal
+        open={true}
+        onClose={mockOnClose}
+        row={{ ...mockCaseData, parentId: 999 }}
+        onRefreshCases={mockOnRefreshCases}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Visualizations')).toBeInTheDocument();
+    });
+  });
+
+  it('switches away from Visualizations tab when it becomes hidden', async () => {
+    const user = userEvent.setup();
+    // Start with a case that shows Visualizations
+    const caseWithPacs: CaseRow = {
+      ...mockCaseData,
+      transaction: JSON.stringify({
+        FIToFIPmtSts: { TxInfAndSts: { OrgnlEndToEndId: 'TXN-001' } },
+      }),
+    };
+    const { rerender } = render(
+      <ViewCaseModal
+        open={true}
+        onClose={mockOnClose}
+        row={caseWithPacs}
+        onRefreshCases={mockOnRefreshCases}
+      />,
+    );
+
+    // Switch to Visualizations tab
+    await user.click(screen.getByText('Visualizations'));
+    expect(screen.getByText(/txn:TXN-001/)).toBeInTheDocument();
+
+    // Now re-render with a row that has no Visualizations
+    const caseNoViz: CaseRow = { ...mockCaseData, transaction: undefined };
+    rerender(
+      <ViewCaseModal
+        open={true}
+        onClose={mockOnClose}
+        row={caseNoViz}
+        onRefreshCases={mockOnRefreshCases}
+      />,
+    );
+
+    // Should have switched back to details tab, Case Actions Panel visible again
+    await waitFor(() => {
+      expect(screen.getByText('Case Actions Panel')).toBeInTheDocument();
+    });
+  });
+
+  it('handles transaction data as object (not JSON string)', async () => {
+    const user = userEvent.setup();
+    const caseWithObjTxn: CaseRow = {
+      ...mockCaseData,
+      transaction: {
+        FIToFIPmtSts: { TxInfAndSts: { OrgnlEndToEndId: 'OBJ-TXN' } },
+      } as unknown,
+    };
+    render(
+      <ViewCaseModal
+        open={true}
+        onClose={mockOnClose}
+        row={caseWithObjTxn}
+        onRefreshCases={mockOnRefreshCases}
+      />,
+    );
+
+    await user.click(screen.getByText('Visualizations'));
+    expect(screen.getByText(/txn:OBJ-TXN/)).toBeInTheDocument();
+  });
+
+  it('extracts transactionId from transaction_id fallback field', async () => {
+    const user = userEvent.setup();
+    const caseWithTxnId: CaseRow = {
+      ...mockCaseData,
+      transaction: JSON.stringify({
+        FIToFIPmtSts: {},
+        transaction_id: 'FALLBACK-TXN',
+      }),
+    };
+    render(
+      <ViewCaseModal
+        open={true}
+        onClose={mockOnClose}
+        row={caseWithTxnId}
+        onRefreshCases={mockOnRefreshCases}
+      />,
+    );
+
+    await user.click(screen.getByText('Visualizations'));
+    expect(screen.getByText(/txn:FALLBACK-TXN/)).toBeInTheDocument();
+  });
+
+  it('extracts transactionId from transactionId (camelCase) fallback field', async () => {
+    const user = userEvent.setup();
+    const caseWithCamelTxn: CaseRow = {
+      ...mockCaseData,
+      transaction: JSON.stringify({
+        FIToFIPmtSts: {},
+        transactionId: 'CAMEL-TXN',
+      }),
+    };
+    render(
+      <ViewCaseModal
+        open={true}
+        onClose={mockOnClose}
+        row={caseWithCamelTxn}
+        onRefreshCases={mockOnRefreshCases}
+      />,
+    );
+
+    await user.click(screen.getByText('Visualizations'));
+    expect(screen.getByText(/txn:CAMEL-TXN/)).toBeInTheDocument();
+  });
+
+  it('returns undefined transactionId when extracted ID is not a string', async () => {
+    const user = userEvent.setup();
+    const caseWithNonStringId: CaseRow = {
+      ...mockCaseData,
+      transaction: JSON.stringify({
+        FIToFIPmtSts: { TxInfAndSts: { OrgnlEndToEndId: 12345 } },
+      }),
+    };
+    render(
+      <ViewCaseModal
+        open={true}
+        onClose={mockOnClose}
+        row={caseWithNonStringId}
+        onRefreshCases={mockOnRefreshCases}
+      />,
+    );
+
+    // Visualizations tab should still show (FIToFIPmtSts exists)
+    await user.click(screen.getByText('Visualizations'));
+    expect(screen.getByText('Visualizations Tab')).toBeInTheDocument();
+    // But no txn: prefix since transactionId is undefined
+    expect(screen.queryByText(/txn:/)).not.toBeInTheDocument();
+  });
+
+  it('handles parent case fetch error for getParentCaseData gracefully', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
+    mockGetCaseDetails.mockRejectedValue(new Error('parent fetch failed'));
+
+    render(
+      <ViewCaseModal
+        open={true}
+        onClose={mockOnClose}
+        row={mockCaseWithParent}
+        onRefreshCases={mockOnRefreshCases}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Failed to refresh case data:',
+        expect.any(Error),
+      );
+    });
+    consoleSpy.mockRestore();
+  });
+
+  it('does not fetch parent case data when row has no parentId', () => {
+    render(
+      <ViewCaseModal
+        open={true}
+        onClose={mockOnClose}
+        row={mockCaseData}
+        onRefreshCases={mockOnRefreshCases}
+      />,
+    );
+
+    // getCaseDetails should not be called for parent (no parentId)
+    // It may be called for refreshCaseData but not for parent
+    expect(mockGetCaseDetails).not.toHaveBeenCalledWith(999);
+  });
+
+  it('handles refreshCaseData error when called from TaskLogTab', async () => {
+    const user = userEvent.setup();
+    // First call succeeds for initial render, second call fails for refresh
+    mockGetCaseDetails
+      .mockResolvedValueOnce({ ...mockCaseData })
+      .mockRejectedValueOnce(new Error('refresh failed'));
+    mockTransformBackendCaseToUI.mockImplementation((c: any) => c);
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => { });
+
+    render(
+      <ViewCaseModal
+        open={true}
+        onClose={mockOnClose}
+        row={mockCaseData}
+        onRefreshCases={mockOnRefreshCases}
+      />,
+    );
+
+    await user.click(screen.getByText('Task Log'));
+    await user.click(screen.getByText('Refresh Cases From Task'));
+
+    await waitFor(() => {
+      expect(mockOnRefreshCases).toHaveBeenCalled();
+    });
+
+    consoleSpy.mockRestore();
+  });
+
+  it('renders Case Details tab content by default', () => {
+    render(
+      <ViewCaseModal
+        open={true}
+        onClose={mockOnClose}
+        row={mockCaseData}
+        onRefreshCases={mockOnRefreshCases}
+      />,
+    );
+
+    expect(screen.getByText('Case Details Tab')).toBeInTheDocument();
+  });
+
+  it('passes canManageSupervisorActions prop', () => {
+    render(
+      <ViewCaseModal
+        open={true}
+        onClose={mockOnClose}
+        row={mockCaseData}
+        onRefreshCases={mockOnRefreshCases}
+        canManageSupervisorActions={true}
+      />,
+    );
+
+    // Component renders without error
+    expect(
+      screen.getByRole('heading', { name: /Case Details/i }),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/features/cases/components/view/TaskDetailsTab.tsx
+++ b/frontend/src/features/cases/components/view/TaskDetailsTab.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import type { CaseRow } from '../casesTable.utils';
 import type { TaskForSupervisor } from '../../services/taskService';
 import { formatDate } from '../../../../shared/utils/dateUtils';

--- a/frontend/src/features/cases/components/view/visualizations/__tests__/TransactionDetailsTab.test.tsx
+++ b/frontend/src/features/cases/components/view/visualizations/__tests__/TransactionDetailsTab.test.tsx
@@ -51,8 +51,10 @@ const makeTransactionData = (overrides?: any) => ({
   amountAndCurrency: [
     {
       originalAmount: 5000,
+      originalCurrency: 'USD',
       exchangeRate: 1.2,
       convertedAmount: 6000,
+      convertedCurrency: 'USD',
     },
   ],
   settlementDetails: {
@@ -156,7 +158,7 @@ describe('TransactionDetailsTab', () => {
     expect(
       screen.getAllByText('Jane Smith Corp').length,
     ).toBeGreaterThanOrEqual(1);
-    expect(screen.getByText('$5,000')).toBeInTheDocument();
+    expect(screen.getAllByText('USD 5,000').length).toBeGreaterThanOrEqual(1);
     expect(
       screen.getAllByText('First National Bank').length,
     ).toBeGreaterThanOrEqual(1);
@@ -182,9 +184,9 @@ describe('TransactionDetailsTab', () => {
     await waitFor(() => {
       expect(screen.getByText('Amount & Currency')).toBeInTheDocument();
     });
-    expect(screen.getByText(/USD \$5,000/)).toBeInTheDocument();
+    expect(screen.getAllByText(/USD 5,000/).length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText('1.2')).toBeInTheDocument();
-    expect(screen.getByText('$6,000')).toBeInTheDocument();
+    expect(screen.getByText('USD 6,000')).toBeInTheDocument();
   });
 
   it('renders settlement details section', async () => {
@@ -218,7 +220,7 @@ describe('TransactionDetailsTab', () => {
   it('handles amountAndCurrency without optional fields', async () => {
     mockGetTransactionDetails.mockResolvedValue(
       makeTransactionData({
-        amountAndCurrency: [{ originalAmount: 100 }],
+        amountAndCurrency: [{ originalAmount: 100, originalCurrency: 'USD' }],
       }),
     );
     render(
@@ -227,7 +229,7 @@ describe('TransactionDetailsTab', () => {
     await waitFor(() => {
       expect(screen.getByText('Amount & Currency')).toBeInTheDocument();
     });
-    expect(screen.getByText(/USD \$100/)).toBeInTheDocument();
+    expect(screen.getByText(/USD 100/)).toBeInTheDocument();
     expect(screen.queryByText('Exchange Rate')).not.toBeInTheDocument();
     expect(screen.queryByText('Converted Amount')).not.toBeInTheDocument();
   });

--- a/frontend/src/features/cases/components/view/visualizations/transactiondetails/TransactionDetailsTab.tsx
+++ b/frontend/src/features/cases/components/view/visualizations/transactiondetails/TransactionDetailsTab.tsx
@@ -259,7 +259,7 @@ const TransactionDetailsTab: React.FC<TransactionDetailsTabProps> = ({
               <div className="h-px w-16 bg-gradient-to-r from-blue-400 to-purple-400"></div>
             </div>
             <div className="text-xl font-bold text-gray-900">
-              ${data.transactionFlow.amount.amount.toLocaleString()}
+              {data.transactionFlow.amount.currency} {data.transactionFlow.amount.amount.toLocaleString()}
             </div>
           </div>
 
@@ -479,7 +479,7 @@ const TransactionDetailsTab: React.FC<TransactionDetailsTabProps> = ({
                       Original Amount
                     </div>
                     <div className="text-sm text-gray-900">
-                      USD ${amountItem.originalAmount.toLocaleString()}
+                      {amountItem.originalCurrency} {amountItem.originalAmount.toLocaleString()}
                     </div>
                   </div>
                 )}
@@ -501,7 +501,7 @@ const TransactionDetailsTab: React.FC<TransactionDetailsTabProps> = ({
                       Converted Amount
                     </div>
                     <div className="text-sm text-gray-900">
-                      ${amountItem.convertedAmount.toLocaleString()}
+                      {amountItem.convertedCurrency} {amountItem.convertedAmount.toLocaleString()}
                     </div>
                   </div>
                 )}

--- a/frontend/src/features/cases/components/view/visualizations/transactiondetails/types/types.ts
+++ b/frontend/src/features/cases/components/view/visualizations/transactiondetails/types/types.ts
@@ -47,9 +47,12 @@ export interface TransactionDetailsDto {
   };
   amountAndCurrency: Array<{
     originalAmount?: number;
+    originalCurrency?: string;
     exchangeRate?: number;
     convertedAmount?: number;
+    convertedCurrency?: string;
     totalCharges?: number;
+    chargeCurrency?: string;
   }>;
   settlementDetails: {
     settlementDate?: string;


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Moved visualization tab from taskDetail to CaseDetail and removed hardcoded dollar sign from Transaction Detail.

## Why are we doing this?
So use can easily access and view visualization directly from CaseDetail view rather than waiting for investigation Case to open.

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done
